### PR TITLE
Phase 12

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,3 +1,4 @@
 from app.api.repositories import router as repositories_router
+from app.api.chat import router as chat_router
 
-__all__ = ["repositories_router"]
+__all__ = ["repositories_router", "chat_router"]

--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -1,0 +1,298 @@
+"""
+Chat API Routes
+
+Endpoints for chat session management and querying with context.
+
+Phase 12: Chat Memory & Session Management
+"""
+
+from fastapi import APIRouter, HTTPException, status
+from typing import Optional, List
+from pydantic import BaseModel
+from app.services.chat_service import ChatService
+from app.services.rag_pipeline import RAGPipeline
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+
+
+class CreateSessionRequest(BaseModel):
+    """Request model for creating a chat session"""
+    repository_id: str
+    user_id: Optional[str] = None
+
+
+class CreateSessionResponse(BaseModel):
+    """Response model for created session"""
+    session_id: str
+    repository_id: str
+    user_id: Optional[str] = None
+    created_at: str
+
+
+class ChatQueryRequest(BaseModel):
+    """Request model for chat query"""
+    question: str
+    repository_id: str
+    session_id: Optional[str] = None
+    limit: int = 5
+
+
+class ChatQueryResponse(BaseModel):
+    """Response model for chat query"""
+    answer: str
+    sources: List[dict]
+    chunks_found: int
+    session_id: Optional[str] = None
+    status: str
+
+
+class MessageResponse(BaseModel):
+    """Response model for a single message"""
+    role: str
+    content: str
+    timestamp: str
+    tokens: Optional[int] = None
+
+
+class SessionResponse(BaseModel):
+    """Response model for session details"""
+    id: str
+    user_id: Optional[str]
+    repository_id: str
+    messages: List[MessageResponse]
+    message_count: int
+    created_at: str
+    updated_at: Optional[str] = None
+
+
+@router.post("/sessions", response_model=CreateSessionResponse, status_code=status.HTTP_201_CREATED)
+async def create_chat_session(request: CreateSessionRequest):
+    """
+    POST /chat/sessions - Create a new chat session
+
+    Creates a new session linked to a repository for multi-turn conversations.
+
+    Args:
+        request: Session creation data (repository_id, optional user_id)
+
+    Returns:
+        Created session with session_id
+    """
+    result = await ChatService.create_session(
+        repository_id=request.repository_id,
+        user_id=request.user_id
+    )
+
+    if result["status"] != "success":
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=result.get("error", "Failed to create session")
+        )
+
+    return {
+        "session_id": result["session_id"],
+        "repository_id": result["repository_id"],
+        "user_id": result.get("user_id"),
+        "created_at": result["created_at"].isoformat()
+    }
+
+
+@router.get("/sessions/{session_id}", response_model=SessionResponse)
+async def get_chat_session(session_id: str):
+    """
+    GET /chat/sessions/{id} - Get session with full history
+
+    Retrieves a chat session including all messages.
+
+    Args:
+        session_id: The session ID
+
+    Returns:
+        Full session with messages
+
+    Raises:
+        404: Session not found
+    """
+    session = await ChatService.get_session(session_id)
+
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session with id '{session_id}' not found"
+        )
+
+    messages = []
+    for msg in session.get("messages", []):
+        messages.append({
+            "role": msg.get("role", "unknown"),
+            "content": msg.get("content", ""),
+            "timestamp": msg.get("timestamp").isoformat() if msg.get("timestamp") else "",
+            "tokens": msg.get("tokens")
+        })
+
+    return {
+        "id": session["id"],
+        "user_id": session.get("user_id"),
+        "repository_id": session["repository_id"],
+        "messages": messages,
+        "message_count": session.get("message_count", 0),
+        "created_at": session["created_at"].isoformat() if session.get("created_at") else "",
+        "updated_at": session["updated_at"].isoformat() if session.get("updated_at") else None
+    }
+
+
+@router.delete("/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_chat_session(session_id: str):
+    """
+    DELETE /chat/sessions/{id} - Delete a chat session
+
+    Permanently deletes a chat session and all its messages.
+
+    Args:
+        session_id: The session ID to delete
+
+    Returns:
+        204 No Content on success
+
+    Raises:
+        404: Session not found
+    """
+    result = await ChatService.delete_session(session_id)
+
+    if result["status"] == "error":
+        if "not found" in result.get("error", "").lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Session with id '{session_id}' not found"
+            )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=result.get("error", "Failed to delete session")
+        )
+
+    return None
+
+
+@router.get("/sessions/{session_id}/history")
+async def get_session_history(session_id: str, limit: int = 20):
+    """
+    GET /chat/sessions/{id}/history - Get recent messages
+
+    Retrieves recent messages from a session without full session details.
+
+    Args:
+        session_id: The session ID
+        limit: Maximum messages to return (default 20)
+
+    Returns:
+        List of recent messages
+    """
+    messages = await ChatService.get_session_history(session_id, limit=limit)
+
+    return {
+        "session_id": session_id,
+        "messages": [
+            {
+                "role": msg.get("role", "unknown"),
+                "content": msg.get("content", ""),
+                "timestamp": msg.get("timestamp").isoformat() if msg.get("timestamp") else "",
+                "tokens": msg.get("tokens")
+            }
+            for msg in messages
+        ],
+        "count": len(messages)
+    }
+
+
+rag_pipeline = RAGPipeline()
+
+
+@router.post("/query", response_model=ChatQueryResponse)
+async def chat_query(request: ChatQueryRequest):
+    """
+    POST /chat/query - Query with optional session context
+
+    Answers a question about the codebase, optionally using chat history
+    for multi-turn conversation context.
+
+    Args:
+        request: Query data (question, repository_id, optional session_id)
+
+    Returns:
+        Answer with source citations
+    """
+    session_id = request.session_id
+
+    if session_id:
+        session = await ChatService.get_session(session_id)
+        if not session:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Session with id '{session_id}' not found"
+            )
+
+    result = await rag_pipeline.query(
+        question=request.question,
+        repository_id=request.repository_id,
+        limit=request.limit,
+        session_id=session_id
+    )
+
+    if session_id and result["status"] == "success":
+        await ChatService.add_message(
+            session_id=session_id,
+            role="user",
+            content=request.question
+        )
+        await ChatService.add_message(
+            session_id=session_id,
+            role="assistant",
+            content=result["answer"]
+        )
+
+    return {
+        "answer": result.get("answer", ""),
+        "sources": result.get("sources", []),
+        "chunks_found": result.get("chunks_found", 0),
+        "session_id": session_id,
+        "status": result.get("status", "unknown")
+    }
+
+
+@router.get("/sessions")
+async def list_sessions(
+    user_id: Optional[str] = None,
+    repository_id: Optional[str] = None,
+    limit: int = 50
+):
+    """
+    GET /chat/sessions - List sessions with optional filters
+
+    Args:
+        user_id: Filter by user ID
+        repository_id: Filter by repository ID
+        limit: Maximum sessions to return
+
+    Returns:
+        List of sessions
+    """
+    sessions = await ChatService.list_user_sessions(
+        user_id=user_id,
+        repository_id=repository_id,
+        limit=limit
+    )
+
+    return {
+        "sessions": [
+            {
+                "id": s["id"],
+                "user_id": s.get("user_id"),
+                "repository_id": s["repository_id"],
+                "message_count": s.get("message_count", 0),
+                "created_at": s["created_at"].isoformat() if s.get("created_at") else "",
+                "updated_at": s.get("updated_at").isoformat() if s.get("updated_at") else None
+            }
+            for s in sessions
+        ],
+        "count": len(sessions)
+    }

--- a/app/models/chat.py
+++ b/app/models/chat.py
@@ -1,0 +1,62 @@
+from pydantic import BaseModel, Field, field_serializer
+from typing import Optional, List
+from datetime import datetime
+from bson import ObjectId
+
+
+class Message(BaseModel):
+    """Individual chat message model"""
+    role: str = Field(..., description="Message role: 'user' or 'assistant'")
+    content: str = Field(..., description="Message content")
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    tokens: Optional[int] = Field(None, description="Token count for the message")
+
+    class Config:
+        from_attributes = True
+
+
+class ChatSessionBase(BaseModel):
+    """Base model for chat session"""
+    repository_id: str = Field(..., description="Associated repository ID")
+
+
+class ChatSessionCreate(ChatSessionBase):
+    """Model for creating a chat session"""
+    user_id: Optional[str] = Field(None, description="User ID if authenticated")
+
+
+class ChatSessionResponse(BaseModel):
+    """Model for API response - includes all session data"""
+    id: str
+    user_id: Optional[str] = None
+    repository_id: str
+    messages: List[Message] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+    message_count: int = 0
+
+    class Config:
+        from_attributes = True
+
+    @field_serializer('id')
+    def serialize_id(self, value):
+        """Convert MongoDB ObjectId to string"""
+        if isinstance(value, ObjectId):
+            return str(value)
+        return value
+
+
+class ChatMessageCreate(BaseModel):
+    """Model for adding a message to a session"""
+    session_id: str = Field(..., description="Session ID to add message to")
+    role: str = Field(..., pattern="^(user|assistant)$", description="Message role")
+    content: str = Field(..., min_length=1, description="Message content")
+    tokens: Optional[int] = Field(None, description="Token count")
+
+
+class ChatQueryRequest(BaseModel):
+    """Model for chat query request with optional session"""
+    question: str = Field(..., min_length=1, description="User's question")
+    repository_id: str = Field(..., description="Repository to query")
+    session_id: Optional[str] = Field(None, description="Optional session for context")
+    limit: int = Field(5, ge=1, le=20, description="Number of chunks to retrieve")

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -9,6 +9,7 @@ from app.services.llm_service import LLMService
 from app.services.processor import RepositoryProcessor
 from app.services.rag_pipeline import RAGPipeline
 from app.services.github_service import GitHubService
+from app.services.chat_service import ChatService
 
 __all__ = [
     "scan_directory",
@@ -23,4 +24,5 @@ __all__ = [
     "RepositoryProcessor",
     "RAGPipeline",
     "GitHubService",
+    "ChatService",
 ]

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -1,0 +1,277 @@
+"""
+Chat Service
+
+Handles session management and chat history persistence in MongoDB.
+
+Phase 12: Chat Memory & Session Management
+"""
+
+import logging
+from typing import Dict, Any, List, Optional
+from datetime import datetime
+from bson import ObjectId
+
+from app.database import Database
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+class ChatService:
+    """Handles chat session CRUD operations with MongoDB"""
+
+    COLLECTION_NAME = "chat_sessions"
+
+    @classmethod
+    async def _get_collection(cls):
+        """Get the chat sessions collection"""
+        db = Database.get_db()
+        return db[cls.COLLECTION_NAME]
+
+    @classmethod
+    async def create_session(
+        cls,
+        repository_id: str,
+        user_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Create a new chat session.
+
+        Args:
+            repository_id: ID of the repository to chat about
+            user_id: Optional user ID for multi-user support
+
+        Returns:
+            Created session with ID
+        """
+        logger.info(f"Creating chat session for repo: {repository_id}")
+
+        collection = await cls._get_collection()
+
+        session_doc = {
+            "user_id": user_id,
+            "repository_id": repository_id,
+            "messages": [],
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow()
+        }
+
+        result = await collection.insert_one(session_doc)
+        session_id = str(result.inserted_id)
+
+        logger.info(f"Created session: {session_id}")
+
+        return {
+            "status": "success",
+            "session_id": session_id,
+            "repository_id": repository_id,
+            "user_id": user_id,
+            "created_at": session_doc["created_at"]
+        }
+
+    @classmethod
+    async def add_message(
+        cls,
+        session_id: str,
+        role: str,
+        content: str,
+        tokens: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """
+        Add a message to an existing session.
+
+        Args:
+            session_id: Session ID to add message to
+            role: 'user' or 'assistant'
+            content: Message content
+            tokens: Optional token count
+
+        Returns:
+            Updated session info
+        """
+        logger.info(f"Adding {role} message to session: {session_id}")
+
+        collection = await cls._get_collection()
+
+        message = {
+            "role": role,
+            "content": content,
+            "timestamp": datetime.utcnow(),
+            "tokens": tokens
+        }
+
+        result = await collection.update_one(
+            {"_id": ObjectId(session_id)},
+            {
+                "$push": {"messages": message},
+                "$set": {"updated_at": datetime.utcnow()}
+            }
+        )
+
+        if result.matched_count == 0:
+            logger.warning(f"Session not found: {session_id}")
+            return {
+                "status": "error",
+                "error": "Session not found"
+            }
+
+        logger.info(f"Message added to session: {session_id}")
+        return {
+            "status": "success",
+            "session_id": session_id,
+            "message_added": True
+        }
+
+    @classmethod
+    async def get_session(
+        cls,
+        session_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Get a session by ID.
+
+        Args:
+            session_id: Session ID to retrieve
+
+        Returns:
+            Session data or None if not found
+        """
+        logger.info(f"Retrieving session: {session_id}")
+
+        collection = await cls._get_collection()
+
+        try:
+            session = await collection.find_one({"_id": ObjectId(session_id)})
+
+            if not session:
+                logger.warning(f"Session not found: {session_id}")
+                return None
+
+            return {
+                "id": str(session["_id"]),
+                "user_id": session.get("user_id"),
+                "repository_id": session["repository_id"],
+                "messages": session.get("messages", []),
+                "created_at": session["created_at"],
+                "updated_at": session.get("updated_at"),
+                "message_count": len(session.get("messages", []))
+            }
+
+        except Exception as e:
+            logger.error(f"Error retrieving session: {str(e)}")
+            return None
+
+    @classmethod
+    async def get_session_history(
+        cls,
+        session_id: str,
+        limit: int = 20
+    ) -> List[Dict[str, Any]]:
+        """
+        Get recent messages from a session.
+
+        Args:
+            session_id: Session ID
+            limit: Maximum number of messages to retrieve (default 20)
+
+        Returns:
+            List of recent messages
+        """
+        logger.info(f"Getting history for session: {session_id}, limit: {limit}")
+
+        session = await cls.get_session(session_id)
+
+        if not session:
+            return []
+
+        messages = session.get("messages", [])
+        recent_messages = messages[-limit:] if limit > 0 else messages
+
+        logger.info(f"Retrieved {len(recent_messages)} messages from session")
+        return recent_messages
+
+    @classmethod
+    async def delete_session(cls, session_id: str) -> Dict[str, Any]:
+        """
+        Delete a chat session.
+
+        Args:
+            session_id: Session ID to delete
+
+        Returns:
+            Deletion result
+        """
+        logger.info(f"Deleting session: {session_id}")
+
+        collection = await cls._get_collection()
+
+        try:
+            result = await collection.delete_one({"_id": ObjectId(session_id)})
+
+            if result.deleted_count == 0:
+                logger.warning(f"Session not found for deletion: {session_id}")
+                return {
+                    "status": "error",
+                    "error": "Session not found"
+                }
+
+            logger.info(f"Deleted session: {session_id}")
+            return {
+                "status": "success",
+                "session_id": session_id,
+                "deleted": True
+            }
+
+        except Exception as e:
+            logger.error(f"Error deleting session: {str(e)}")
+            return {
+                "status": "error",
+                "error": str(e)
+            }
+
+    @classmethod
+    async def list_user_sessions(
+        cls,
+        user_id: Optional[str] = None,
+        repository_id: Optional[str] = None,
+        limit: int = 50
+    ) -> List[Dict[str, Any]]:
+        """
+        List sessions, optionally filtered by user or repository.
+
+        Args:
+            user_id: Filter by user ID
+            repository_id: Filter by repository ID
+            limit: Maximum sessions to return
+
+        Returns:
+            List of sessions
+        """
+        logger.info(f"Listing sessions - user: {user_id}, repo: {repository_id}")
+
+        collection = await cls._get_collection()
+
+        query = {}
+        if user_id:
+            query["user_id"] = user_id
+        if repository_id:
+            query["repository_id"] = repository_id
+
+        cursor = collection.find(query).sort("updated_at", -1).limit(limit)
+
+        sessions = []
+        async for session in cursor:
+            sessions.append({
+                "id": str(session["_id"]),
+                "user_id": session.get("user_id"),
+                "repository_id": session["repository_id"],
+                "created_at": session["created_at"],
+                "updated_at": session.get("updated_at"),
+                "message_count": len(session.get("messages", []))
+            })
+
+        logger.info(f"Found {len(sessions)} sessions")
+        return sessions

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -1,5 +1,5 @@
 from openai import AsyncOpenAI, RateLimitError, APIError
-from typing import List, Dict, Any, AsyncIterator
+from typing import List, Dict, Any, AsyncIterator, Optional
 import os
 from dotenv import load_dotenv
 
@@ -8,6 +8,8 @@ load_dotenv()
 
 class LLMService:
     """Handles LLM interactions for answer generation"""
+
+    MAX_HISTORY_TOKENS = 2000
 
     def __init__(self):
         api_key = os.getenv("OPENAI_API_KEY")
@@ -41,7 +43,25 @@ class LLMService:
 
         return "\n".join(context_parts)
 
-    def _build_prompt(self, query: str, context: str) -> List[Dict[str, str]]:
+    def _format_history(self, history: List[Dict[str, Any]]) -> str:
+        """Format chat history for inclusion in prompt"""
+        if not history:
+            return ""
+
+        history_parts = []
+        for msg in history:
+            role = msg.get("role", "unknown")
+            content = msg.get("content", "")
+            history_parts.append(f"{role.upper()}: {content}")
+
+        return "\n\n".join(history_parts)
+
+    def _build_prompt(
+        self,
+        query: str,
+        context: str,
+        chat_history: Optional[List[Dict[str, Any]]] = None
+    ) -> List[Dict[str, str]]:
         """Build prompt with system and user messages"""
 
         system_prompt = """You are an expert code analyst specializing in understanding and explaining software codebases.
@@ -52,11 +72,22 @@ When answering questions:
 3. If the answer isn't in the context, clearly state that
 4. Provide clear, actionable explanations
 5. Use markdown formatting for readability
-6. Focus on explaining HOW the code works, not just WHAT it does"""
+6. Focus on explaining HOW the code works, not just WHAT it does
+7. Use conversation history to maintain context in multi-turn conversations"""
+
+        history_text = self._format_history(chat_history) if chat_history else ""
+
+        history_section = f"""
+Previous conversation:
+---
+{history_text}
+---
+
+""" if history_text else ""
 
         user_prompt = f"""Based on the following code context from the uploaded repository, answer the user's question.
 
-Context:
+{history_section}Context:
 ---
 {context}
 ---
@@ -73,7 +104,8 @@ Provide your answer with source citations in the format [filename:lines]. If the
     async def generate_answer(
         self,
         query: str,
-        retrieved_chunks: List[Dict[str, Any]]
+        retrieved_chunks: List[Dict[str, Any]],
+        chat_history: Optional[List[Dict[str, Any]]] = None
     ) -> Dict[str, Any]:
         """Generate answer from retrieved context"""
 
@@ -85,7 +117,7 @@ Provide your answer with source citations in the format [filename:lines]. If the
 
         try:
             context = self._format_context(retrieved_chunks)
-            messages = self._build_prompt(query, context)
+            messages = self._build_prompt(query, context, chat_history)
 
             response = await self.client.chat.completions.create(
                 model=self.model,
@@ -136,7 +168,8 @@ Provide your answer with source citations in the format [filename:lines]. If the
     async def generate_streaming_answer(
         self,
         query: str,
-        retrieved_chunks: List[Dict[str, Any]]
+        retrieved_chunks: List[Dict[str, Any]],
+        chat_history: Optional[List[Dict[str, Any]]] = None
     ) -> AsyncIterator[Dict[str, Any]]:
         """Generate answer with streaming responses"""
 
@@ -145,6 +178,69 @@ Provide your answer with source citations in the format [filename:lines]. If the
                 "type": "done",
                 "answer": "No relevant code found for your question.",
                 "sources": []
+            }
+            return
+
+        try:
+            context = self._format_context(retrieved_chunks)
+            messages = self._build_prompt(query, context, chat_history)
+
+            stream = await self.client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+                stream=True
+            )
+
+            sources = []
+            for chunk in retrieved_chunks:
+                metadata = chunk.get("metadata", {})
+                sources.append({
+                    "file_path": metadata.get("file_path", ""),
+                    "start_line": metadata.get("start_line", 0),
+                    "end_line": metadata.get("end_line", 0),
+                    "chunk_type": metadata.get("chunk_type", "code"),
+                    "name": metadata.get("name", ""),
+                    "score": chunk.get("final_score", chunk.get("hybrid_score", 0))
+                })
+
+            full_answer = ""
+
+            async for chunk in stream:
+                if chunk.choices[0].delta.content:
+                    token = chunk.choices[0].delta.content
+                    full_answer += token
+                    yield {
+                        "type": "token",
+                        "token": token,
+                        "answer": full_answer
+                    }
+
+            yield {
+                "type": "done",
+                "answer": full_answer,
+                "sources": sources,
+                "chunks_used": len(retrieved_chunks)
+            }
+
+        except RateLimitError:
+            yield {
+                "type": "error",
+                "answer": "Rate limit reached. Please wait a moment and try again.",
+                "error": "rate_limit"
+            }
+        except APIError as e:
+            yield {
+                "type": "error",
+                "answer": f"API error occurred: {str(e)}",
+                "error": "api_error"
+            }
+        except Exception as e:
+            yield {
+                "type": "error",
+                "answer": f"Error: {str(e)}",
+                "error": "unknown"
             }
             return
 

--- a/app/services/rag_pipeline.py
+++ b/app/services/rag_pipeline.py
@@ -6,6 +6,7 @@ Orchestrates the complete Retrieval Augmented Generation pipeline:
 - Query: Query → Search → Generate → Response
 
 Phase 10: End-to-End RAG Pipeline
+Phase 12: Added session/history support
 """
 
 import logging
@@ -15,6 +16,7 @@ from typing import Dict, Any, List, Optional
 from app.services.processor import RepositoryProcessor
 from app.services.hybrid_search import HybridSearchService
 from app.services.llm_service import LLMService
+from app.services.chat_service import ChatService
 
 logging.basicConfig(
     level=logging.INFO,
@@ -37,6 +39,7 @@ class RAGPipeline:
         self.processor = RepositoryProcessor()
         self.search_service = HybridSearchService()
         self.llm_service = LLMService()
+        self.chat_service = ChatService()
         logger.info("RAGPipeline initialized")
     
     async def ingest_repository(
@@ -98,7 +101,8 @@ class RAGPipeline:
         self,
         question: str,
         repository_id: str,
-        limit: int = 5
+        limit: int = 5,
+        session_id: Optional[str] = None
     ) -> Dict[str, Any]:
         """
         Query pipeline: Answer a question about the codebase.
@@ -109,6 +113,7 @@ class RAGPipeline:
             question: User's question
             repository_id: Repository to query
             limit: Number of code chunks to retrieve
+            session_id: Optional session ID for conversation history
             
         Returns:
             Answer with source citations
@@ -126,6 +131,15 @@ class RAGPipeline:
                     "sources": []
                 }
             
+            chat_history = []
+            if session_id:
+                logger.info(f"Fetching chat history for session: {session_id}")
+                chat_history = await self.chat_service.get_session_history(
+                    session_id, limit=10
+                )
+                if chat_history:
+                    logger.info(f"Using {len(chat_history)} previous messages for context")
+            
             logger.info(f"Stage 1/3: Performing hybrid search...")
             search_results = await self.search_service.hybrid_search(
                 question, repository_id, limit=limit
@@ -137,14 +151,15 @@ class RAGPipeline:
                     "status": "success",
                     "answer": "No relevant code found for your question. Try rephrasing or asking about a different aspect of the codebase.",
                     "sources": [],
-                    "chunks_found": 0
+                    "chunks_found": 0,
+                    "session_id": session_id
                 }
             
             logger.info(f"Stage 2/3: Found {len(search_results)} relevant chunks")
             
             logger.info(f"Stage 3/3: Generating answer with LLM...")
             llm_result = await self.llm_service.generate_answer(
-                question, search_results
+                question, search_results, chat_history=chat_history
             )
             
             elapsed = time.time() - start_time
@@ -167,7 +182,8 @@ class RAGPipeline:
                 "answer": llm_result.get("answer", ""),
                 "sources": sources,
                 "chunks_found": len(search_results),
-                "processing_time_seconds": round(elapsed, 2)
+                "processing_time_seconds": round(elapsed, 2),
+                "session_id": session_id
             }
             
         except Exception as e:
@@ -176,14 +192,16 @@ class RAGPipeline:
                 "status": "error",
                 "answer": f"Error processing your question: {str(e)}",
                 "sources": [],
-                "chunks_found": 0
+                "chunks_found": 0,
+                "session_id": session_id
             }
     
     async def query_with_streaming(
         self,
         question: str,
         repository_id: str,
-        limit: int = 5
+        limit: int = 5,
+        session_id: Optional[str] = None
     ):
         """
         Query pipeline with streaming response.
@@ -192,6 +210,7 @@ class RAGPipeline:
             question: User's question
             repository_id: Repository to query
             limit: Number of code chunks to retrieve
+            session_id: Optional session ID for conversation history
             
         Yields:
             Streaming response tokens
@@ -199,6 +218,12 @@ class RAGPipeline:
         logger.info(f"Starting streaming query for repository: {repository_id}")
         
         try:
+            chat_history = []
+            if session_id:
+                chat_history = await self.chat_service.get_session_history(
+                    session_id, limit=10
+                )
+            
             search_results = await self.search_service.hybrid_search(
                 question, repository_id, limit=limit
             )
@@ -212,7 +237,7 @@ class RAGPipeline:
                 return
             
             async for chunk in self.llm_service.generate_streaming_answer(
-                question, search_results
+                question, search_results, chat_history=chat_history
             ):
                 yield chunk
                 

--- a/main.py
+++ b/main.py
@@ -40,9 +40,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-from app.api import repositories_router
+from app.api import repositories_router, chat_router
 
 app.include_router(repositories_router)
+app.include_router(chat_router)
 
 
 @app.get("/")


### PR DESCRIPTION
## Phase 12: Chat Memory & Session Management

Implements multi-turn conversation support with session persistence.

### Changes
- **Models**: Added `ChatSession` and `Message` Pydantic models
- **Service**: Created `ChatService` for session CRUD operations
- **API**: Added chat endpoints for session management
- **RAG Pipeline**: Updated to include conversation history in context

### Endpoints Added
- `POST /api/chat/sessions` - Create new session
- `GET /api/chat/sessions/{id}` - Get session with history
- `DELETE /api/chat/sessions/{id}` - Delete session
- `POST /api/chat/query` - Query with optional session context

Closes #21