### PR TITLE
fix: pin bcrypt==4.0.1 for passlib compatibility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,5 +8,6 @@ openai==1.12.0
 PyGithub==2.2.0
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
+bcrypt==4.0.1
 slowapi==0.1.9
 numpy==2.2.2


### PR DESCRIPTION
## Summary
- Pin bcrypt version to 4.0.1 for passlib 1.7.4 compatibility
- bcrypt 5.0.0 causes registration to fail with 

## Testing
- Verified registration and login endpoints work correctly after fix

Closes #31