### PR TITLE
Phase 3: Cohere Cross-Encoder Re-ranking + Citation Enforcement

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,3 +13,12 @@ JWT_SECRET=your-super-secret-key-change-in-production
 
 # CORS origins (comma-separated)
 ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+# Cohere API key — enables cross-encoder re-ranking after RRF fusion
+# Free tier: 1,000 requests/month. Get key at https://cohere.com
+# Optional: omit to use heuristic re-ranking fallback
+COHERE_API_KEY=
+
+# LLM model override (default: gpt-4o-mini)
+# Options: gpt-4o-mini, gpt-4o, gpt-4
+LLM_MODEL=

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 slowapi==0.1.9
 numpy==2.2.2
+cohere>=5.0.0
 
 # Testing
 pytest==7.4.4

--- a/backend/services/hybrid_search.py
+++ b/backend/services/hybrid_search.py
@@ -1,17 +1,12 @@
-"""
-Hybrid Search Service
-
-Combines semantic search (vector similarity) and keyword search (exact matching)
-using Reciprocal Rank Fusion (RRF) algorithm.
-
-Phase 8: Hybrid Search Implementation
-"""
-
 from backend.services.vector_store import VectorStore
 from backend.services.keyword_search import KeywordSearchService
 from typing import List, Dict, Any, Optional
 from collections import defaultdict
 import hashlib
+import logging
+import os
+
+logger = logging.getLogger(__name__)
 
 
 class HybridSearchService:
@@ -52,9 +47,13 @@ class HybridSearchService:
         )
         
         combined = self._reciprocal_rank_fusion(semantic_results, keyword_results)
-        
-        reranked = self._rerank(combined, query)
-        
+
+        try:
+            reranked = await self._cohere_rerank(combined, query, limit)
+        except Exception as e:
+            logger.warning("Cohere rerank unavailable (%s), using heuristic rerank", e)
+            reranked = self._rerank(combined, query)
+
         return reranked[:limit]
     
     def _reciprocal_rank_fusion(
@@ -105,6 +104,44 @@ class HybridSearchService:
         
         return results
     
+    async def _cohere_rerank(
+        self,
+        results: List[Dict],
+        query: str,
+        limit: int
+    ) -> List[Dict]:
+        """Re-rank RRF results using the Cohere cross-encoder.
+
+        Reads query + chunk content together (cross-encoder) rather than
+        relying on rank positions alone. Requires COHERE_API_KEY env var.
+        Raises if key is absent or the API call fails, so callers can fall back.
+        """
+        api_key = os.getenv("COHERE_API_KEY")
+        if not api_key:
+            raise ValueError("COHERE_API_KEY not configured")
+
+        import cohere
+        co = cohere.AsyncClientV2(api_key)
+
+        docs = [r.get("content", "") for r in results]
+        top_n = min(limit, len(docs))
+
+        response = await co.rerank(
+            model="rerank-english-v3.0",
+            query=query,
+            documents=docs,
+            top_n=top_n
+        )
+
+        reranked = []
+        for r in response.results:
+            doc = results[r.index].copy()
+            doc["rerank_score"] = r.relevance_score
+            doc["hybrid_score"] = r.relevance_score
+            reranked.append(doc)
+
+        return reranked
+
     def _get_doc_id(self, doc: Dict) -> str:
         """Generate unique ID for a document
         

--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -101,6 +101,38 @@ Provide your answer with source citations in the format [filename:lines]. If the
             {"role": "user", "content": user_prompt}
         ]
 
+    def _validate_citations(
+        self,
+        answer: str,
+        retrieved_chunks: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Validate that file paths cited in the answer exist in retrieved chunks.
+
+        Extracts all .py paths from the answer text and checks each against
+        the file_path metadata of the chunks that were actually retrieved.
+        Returns a dict with citation_valid flag and list of unverified paths.
+        """
+        import re
+
+        cited_files = set(re.findall(r'[\w/._-]+\.py', answer))
+
+        source_paths = {
+            chunk.get("metadata", {}).get("file_path", "")
+            for chunk in retrieved_chunks
+        }
+        source_basenames = {fp.split("/")[-1] for fp in source_paths if fp}
+
+        hallucinated = [
+            f for f in cited_files
+            if f not in source_paths and f.split("/")[-1] not in source_basenames
+        ]
+
+        return {
+            "cited_files": sorted(cited_files),
+            "hallucinated_files": hallucinated,
+            "citation_valid": len(hallucinated) == 0
+        }
+
     async def generate_answer(
         self,
         query: str,
@@ -128,6 +160,14 @@ Provide your answer with source citations in the format [filename:lines]. If the
 
             answer = response.choices[0].message.content
 
+            citation_check = self._validate_citations(answer, retrieved_chunks)
+            if citation_check["hallucinated_files"]:
+                unverified = ", ".join(f"`{f}`" for f in citation_check["hallucinated_files"])
+                answer += (
+                    f"\n\n> **Note**: The following file references could not be "
+                    f"verified against the indexed source: {unverified}"
+                )
+
             sources = []
             for chunk in retrieved_chunks:
                 metadata = chunk.get("metadata", {})
@@ -143,7 +183,9 @@ Provide your answer with source citations in the format [filename:lines]. If the
             return {
                 "answer": answer,
                 "sources": sources,
-                "chunks_used": len(retrieved_chunks)
+                "chunks_used": len(retrieved_chunks),
+                "citation_valid": citation_check["citation_valid"],
+                "citation_warnings": citation_check["hallucinated_files"]
             }
 
         except RateLimitError:


### PR DESCRIPTION
## Summary

- **Cohere re-ranking**: after RRF fusion, candidates are re-scored by a cross-encoder ML model (Cohere `rerank-english-v3.0`) that reads query + chunk content together — significantly better ranking for ambiguous queries than rank-position heuristics
- **Citation enforcement**: LLM answers are post-processed to validate every `.py` file path cited against the retrieved chunks; hallucinated paths trigger a visible blockquote note in the answer and a `citation_warnings` list in the API response
- Both features degrade gracefully: Cohere falls back to heuristic rerank when `COHERE_API_KEY` is absent; citation check runs in all cases

## Closes

Closes #45

## Changes

### `backend/services/hybrid_search.py`
- `_cohere_rerank`: `cohere.AsyncClientV2.rerank()` call; populates `rerank_score` and overwrites `hybrid_score` with cross-encoder relevance score
- `hybrid_search`: replaces direct `_rerank` call with `_cohere_rerank` + exception-caught fallback to `_rerank`

### `backend/services/llm_service.py`
- `_validate_citations`: regex extracts `.py` paths from answer text; matches against retrieved chunk `file_path` metadata (full path and basename)
- `generate_answer`: appends blockquote warning for hallucinated paths; response now includes `citation_valid: bool` and `citation_warnings: list[str]`

### `backend/requirements.txt`
- Added `cohere>=5.0.0`

### `backend/.env.example`
- Added `COHERE_API_KEY` (documented as optional, free tier 1k req/month)
- Added `LLM_MODEL` override with available options

## Test Plan

- [ ] All 41 tests pass (`pytest backend/tests/ -q`)
- [ ] Without `COHERE_API_KEY`: queries complete via heuristic rerank; no error raised
- [ ] With `COHERE_API_KEY` set: `rerank_score` present on returned chunks
- [ ] Answer citing a file not in retrieved chunks includes blockquote note and `citation_warnings` list
- [ ] Answer citing only valid source files has `citation_valid: true` and empty `citation_warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)