### PR TITLE
Phase 4: GitHub URL Repository Import

### DIFF
--- a/backend/api/repositories.py
+++ b/backend/api/repositories.py
@@ -17,12 +17,18 @@ import os
 import shutil
 import tempfile
 
+import asyncio
+import logging
+import re
+
 from backend.database import Database
-from backend.models.repository import RepositoryCreate, RepositoryResponse, RepositoryUpdate
+from backend.models.repository import RepositoryCreate, RepositoryImport, RepositoryResponse, RepositoryUpdate
 from backend.auth.dependencies import get_current_user
 from backend.middleware.rate_limiter import limiter
 from backend.services.processor import RepositoryProcessor
 from backend.services.keyword_search import KeywordSearchService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/repositories", tags=["repositories"])
 
@@ -460,4 +466,98 @@ async def get_repository_stats(
         "repository_id": repo_id,
         "chunk_count": stats.get("chunk_count", 0),
         "indexed": stats.get("indexed", False)
+    }
+
+
+_GITHUB_URL_RE = re.compile(
+    r'^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\.git)?/?$'
+)
+
+
+@router.post("/import", status_code=status.HTTP_201_CREATED)
+@limiter.limit("5/minute")
+async def import_repository(
+    request: Request,
+    payload: RepositoryImport,
+    current_user: dict = Depends(get_current_user)
+):
+    """Clone a public GitHub repository and index it.
+
+    Accepts a GitHub HTTPS URL, clones with depth=1 into a temporary
+    directory, runs the standard RepositoryProcessor pipeline, then
+    cleans up the clone. Private repositories are not supported without
+    a configured GitHub token.
+
+    Rate limit: 5 requests per minute (clone is network-bound).
+    """
+    url = payload.url.strip().rstrip("/")
+    if url.endswith(".git"):
+        url = url[:-4]
+
+    if not _GITHUB_URL_RE.match(url + "/"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="URL must be a public GitHub repository (https://github.com/owner/repo)"
+        )
+
+    repo_slug = url.split("/")[-1]
+    repo_name = payload.name or repo_slug
+    db = Database.get_db()
+    user_id = current_user.get("user_id")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        clone_path = os.path.join(temp_dir, repo_slug)
+
+        proc = await asyncio.create_subprocess_exec(
+            "git", "clone", "--depth", "1", url, clone_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE
+        )
+        try:
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
+        except asyncio.TimeoutError:
+            proc.kill()
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Clone timed out after 120 seconds"
+            )
+
+        if proc.returncode != 0:
+            error_msg = stderr.decode(errors="replace").strip()
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Clone failed: {error_msg}"
+            )
+
+        doc = {
+            "name": repo_name,
+            "description": payload.description or f"Imported from {url}",
+            "user_id": user_id,
+            "source_url": url,
+            "created_at": datetime.now(),
+            "updated_at": None
+        }
+
+        result = await db.repositories.insert_one(doc)
+        repo_id = str(result.inserted_id)
+
+        try:
+            processor = RepositoryProcessor()
+            processing_result = await processor.process_repository(repo_id, clone_path)
+        except Exception as exc:
+            await db.repositories.delete_one({"_id": result.inserted_id})
+            logger.error("Processing failed for import %s: %s", url, exc)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Indexing failed: {exc}"
+            )
+
+    return {
+        "id": repo_id,
+        "name": repo_name,
+        "description": doc["description"],
+        "source_url": url,
+        "created_at": doc["created_at"],
+        "updated_at": None,
+        "processing": processing_result
     }

--- a/backend/models/repository.py
+++ b/backend/models/repository.py
@@ -16,6 +16,13 @@ class RepositoryCreate(RepositoryBase):
     pass
 
 
+class RepositoryImport(BaseModel):
+    """Model for importing a repository from a GitHub URL"""
+    url: str = Field(..., description="Public GitHub repository URL")
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    description: Optional[str] = None
+
+
 class RepositoryUpdate(BaseModel):
     """Model for updating a repository - all fields optional"""
     name: Optional[str] = Field(None, min_length=1, max_length=100)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,10 @@ function App() {
   const [uploadFile, setUploadFile] = useState(null)
   const [uploadStatus, setUploadStatus] = useState('')
 
+  // GitHub import state
+  const [githubUrl, setGithubUrl] = useState('')
+  const [importStatus, setImportStatus] = useState('')
+
   // Chat state
   const [question, setQuestion] = useState('')
   const [loading, setLoading] = useState(false)
@@ -118,6 +122,26 @@ function App() {
     } finally {
       setLoading(false)
       setTimeout(() => setUploadStatus(''), 4000)
+    }
+  }
+
+  const handleGitHubImport = async () => {
+    if (!githubUrl.trim()) return
+    setLoading(true)
+    setImportStatus('Cloning and indexing...')
+    try {
+      await axios.post(`${API_URL}/repositories/import`,
+        { url: githubUrl.trim() },
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      setImportStatus('Done! Repository indexed.')
+      setGithubUrl('')
+      fetchRepositories(token)
+    } catch (err) {
+      setImportStatus('Import failed: ' + (err.response?.data?.detail || err.message))
+    } finally {
+      setLoading(false)
+      setTimeout(() => setImportStatus(''), 5000)
     }
   }
 
@@ -323,6 +347,22 @@ function App() {
               />
               <button onClick={handleUpload} disabled={loading || !uploadFile}>
                 {uploadStatus || 'Upload ZIP'}
+              </button>
+            </div>
+          </section>
+
+          <section className="upload-section">
+            <h2>Import from GitHub</h2>
+            <div className="upload-form">
+              <input
+                type="url"
+                placeholder="https://github.com/owner/repo"
+                value={githubUrl}
+                onChange={(e) => setGithubUrl(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleGitHubImport()}
+              />
+              <button onClick={handleGitHubImport} disabled={loading || !githubUrl.trim()}>
+                {importStatus || 'Import'}
               </button>
             </div>
           </section>


### PR DESCRIPTION
## Summary

- New `POST /repositories/import` endpoint: accepts a GitHub HTTPS URL, clones with `git clone --depth 1`, indexes through the existing `RepositoryProcessor` pipeline, and returns the same response shape as `/upload`
- Non-GitHub URLs rejected with 400; clone failures (private repo, typo) return 422 with the git error message; DB record is rolled back on indexing failure
- Temp clone directory always cleaned up via `try/finally` inside `TemporaryDirectory` context
- Frontend sidebar: "Import from GitHub" section with URL input, Enter-key submit, inline status, and automatic repo list refresh on success

## Closes

Closes #47

## Changes

### `backend/models/repository.py`
- Added `RepositoryImport(url, name?, description?)` Pydantic model

### `backend/api/repositories.py`
- Added `_GITHUB_URL_RE` regex constant for URL validation
- Added `POST /repositories/import` endpoint (rate limit 5/minute)
- Imports: `asyncio`, `logging`, `re`, `RepositoryImport`

### `frontend/src/App.jsx`
- State: `githubUrl`, `importStatus`
- Handler: `handleGitHubImport` — POST to `/repositories/import`, refresh repos on success
- UI: "Import from GitHub" section between upload and repo selector

## Test Plan

- [ ] All 41 tests pass (`pytest backend/tests/ -q`)
- [ ] Valid public URL (e.g. `https://github.com/pallets/flask`) → repository created and indexed
- [ ] Non-GitHub URL → 400 Bad Request
- [ ] Invalid or private repo URL → 422 with git stderr message
- [ ] Clone timeout (120s) → 422 "Clone timed out"
- [ ] Temp directory absent after request completes (success and failure)
- [ ] Frontend: URL input visible in sidebar; imported repo appears in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)