### PR TITLE
Phase 5: Multi-language Indexing via tree-sitter

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,13 @@ bcrypt==4.0.1
 slowapi==0.1.9
 numpy==2.2.2
 cohere>=5.0.0
+tree-sitter>=0.21.0
+tree-sitter-python
+tree-sitter-javascript
+tree-sitter-typescript
+tree-sitter-go
+tree-sitter-java
+tree-sitter-rust
 
 # Testing
 pytest==7.4.4

--- a/backend/services/chunker.py
+++ b/backend/services/chunker.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Any, Optional
 import ast
 
 from backend.services.ast_parser import parse_python_file
+from backend.services import treesitter_parser
 
 
 class CodeChunker:
@@ -187,6 +188,103 @@ class CodeChunker:
         
         return pieces
     
+    def chunk_file_multilang(
+        self, source: str, file_path: str = "", language: str = "python"
+    ) -> List[Dict[str, Any]]:
+        """Chunk any supported language file using AST where possible.
+
+        Dispatch order:
+          1. Python  → existing `chunk_file` (Python ast module)
+          2. Other   → tree-sitter AST; same chunk assembly as Python path
+          3. Fallback → line-based chunking when tree-sitter is unavailable
+        """
+        if language == "python":
+            return self.chunk_file(source, file_path)
+
+        parsed = treesitter_parser.parse_file(source, language)
+        if parsed is not None:
+            return self._chunks_from_parsed(source, file_path, parsed)
+
+        # Tree-sitter not available for this language — use line-based chunking
+        return self._chunk_by_lines(source, file_path)
+
+    def _chunks_from_parsed(
+        self, source: str, file_path: str, parsed: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        """Assemble chunks from a treesitter_parser result dict."""
+        chunks = []
+
+        for func in parsed.get("functions", []):
+            func_source = self._extract_lines(source, func["line_start"], func["line_end"])
+            chunks.append(self._create_chunk(
+                content=func_source,
+                chunk_type="function",
+                name=func["name"],
+                start_line=func["line_start"],
+                end_line=func["line_end"],
+                file_path=file_path,
+            ))
+
+        for cls in parsed.get("classes", []):
+            cls_source = self._extract_lines(source, cls["line_start"], cls["line_end"])
+            chunks.append(self._create_chunk(
+                content=cls_source,
+                chunk_type="class",
+                name=cls["name"],
+                start_line=cls["line_start"],
+                end_line=cls["line_end"],
+                file_path=file_path,
+            ))
+
+        if not chunks:
+            # No functions/classes found — chunk the whole file by lines
+            return self._chunk_by_lines(source, file_path)
+
+        return self._split_large_chunks(chunks)
+
+    def _chunk_by_lines(self, source: str, file_path: str) -> List[Dict[str, Any]]:
+        """Sliding-window line-based chunking for files without AST support."""
+        if not source or not source.strip():
+            return []
+
+        lines = source.split("\n")
+        chunks = []
+        current_lines: List[str] = []
+        current_tokens = 0
+        start_line = 1
+
+        for i, line in enumerate(lines, 1):
+            line_tokens = self.count_tokens(line + "\n")
+
+            if current_tokens + line_tokens > self.max_tokens and current_lines:
+                chunks.append(self._create_chunk(
+                    content="\n".join(current_lines),
+                    chunk_type="code",
+                    name="",
+                    start_line=start_line,
+                    end_line=i - 1,
+                    file_path=file_path,
+                ))
+                overlap = current_lines[-self.overlap:] if self.overlap < len(current_lines) else []
+                current_lines = overlap + [line]
+                current_tokens = self.count_tokens("\n".join(current_lines))
+                start_line = i - len(overlap)
+            else:
+                current_lines.append(line)
+                current_tokens += line_tokens
+
+        if current_lines:
+            chunks.append(self._create_chunk(
+                content="\n".join(current_lines),
+                chunk_type="code",
+                name="",
+                start_line=start_line,
+                end_line=len(lines),
+                file_path=file_path,
+            ))
+
+        return chunks
+
     def chunk_directory(self, directory: str) -> List[Dict[str, Any]]:
         """Chunk all Python files in a directory
         
@@ -202,12 +300,11 @@ class CodeChunker:
         files = scan_directory(directory)
         
         for file_info in files:
-            if file_info["language"] != "python":
-                continue
-            
             content = get_file_content(file_info["path"])
             if content:
-                chunks = self.chunk_file(content, file_info["relative_path"])
+                chunks = self.chunk_file_multilang(
+                    content, file_info["relative_path"], file_info["language"]
+                )
                 for chunk in chunks:
                     chunk["repository_id"] = ""
                 all_chunks.extend(chunks)

--- a/backend/services/processor.py
+++ b/backend/services/processor.py
@@ -39,12 +39,11 @@ class RepositoryProcessor:
         all_chunks = []
         
         for file_info in files:
-            if file_info["language"] != "python":
-                continue
-            
             content = get_file_content(file_info["path"])
             if content:
-                chunks = self.chunker.chunk_file(content, file_info["relative_path"])
+                chunks = self.chunker.chunk_file_multilang(
+                    content, file_info["relative_path"], file_info["language"]
+                )
                 all_chunks.extend(chunks)
         
         if not all_chunks:

--- a/backend/services/treesitter_parser.py
+++ b/backend/services/treesitter_parser.py
@@ -1,0 +1,152 @@
+"""
+Multi-language AST parser using tree-sitter.
+
+Extracts functions and classes from JS, TS, Go, Java, Rust, and Ruby source files.
+Returns None when a grammar package is not installed, allowing callers to fall back
+to line-based chunking without failing.
+"""
+
+from typing import Any, Dict, List, Optional, Set, Tuple
+import importlib
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Maps language name → (tree-sitter package, language factory function, function node types, class node types)
+_LANG_CONFIG: Dict[str, Tuple[str, str, Set[str], Set[str]]] = {
+    "javascript": (
+        "tree_sitter_javascript", "language",
+        {"function_declaration", "function_expression", "arrow_function",
+         "method_definition", "generator_function_declaration"},
+        {"class_declaration", "class"},
+    ),
+    "typescript": (
+        "tree_sitter_typescript", "language_typescript",
+        {"function_declaration", "function_expression", "arrow_function",
+         "method_definition", "abstract_method_signature"},
+        {"class_declaration", "interface_declaration"},
+    ),
+    "go": (
+        "tree_sitter_go", "language",
+        {"function_declaration", "method_declaration"},
+        {"type_declaration"},
+    ),
+    "java": (
+        "tree_sitter_java", "language",
+        {"method_declaration", "constructor_declaration"},
+        {"class_declaration", "interface_declaration", "enum_declaration"},
+    ),
+    "rust": (
+        "tree_sitter_rust", "language",
+        {"function_item"},
+        {"struct_item", "enum_item", "trait_item", "impl_item"},
+    ),
+    "ruby": (
+        "tree_sitter_ruby", "language",
+        {"method", "singleton_method"},
+        {"class", "module"},
+    ),
+}
+
+
+def _get_parser(language: str):
+    """Build a tree-sitter Parser for the given language, or return None."""
+    config = _LANG_CONFIG.get(language)
+    if not config:
+        return None, None, None
+
+    pkg_name, func_name, func_types, class_types = config
+
+    try:
+        import tree_sitter
+
+        module = importlib.import_module(pkg_name)
+        lang_factory = getattr(module, func_name)
+        ts_lang = tree_sitter.Language(lang_factory())
+
+        parser = tree_sitter.Parser()
+        parser.language = ts_lang
+
+        return parser, func_types, class_types
+
+    except ImportError:
+        logger.debug("tree-sitter grammar not installed for '%s' (%s)", language, pkg_name)
+        return None, None, None
+    except Exception as exc:
+        logger.warning("Failed to load tree-sitter grammar for '%s': %s", language, exc)
+        return None, None, None
+
+
+def _node_name(node) -> Optional[str]:
+    """Return the name of a function/class node."""
+    # Prefer the dedicated 'name' field present in most grammars
+    name_node = node.child_by_field_name("name")
+    if name_node:
+        return name_node.text.decode("utf-8", errors="replace")
+
+    # Fallback: first identifier-like child
+    identifier_types = {"identifier", "property_identifier", "field_identifier", "type_identifier"}
+    for child in node.children:
+        if child.type in identifier_types:
+            return child.text.decode("utf-8", errors="replace")
+
+    return None
+
+
+def _walk(node, func_types: Set[str], class_types: Set[str]) -> Tuple[List, List]:
+    """Recursively extract functions and classes from a parse tree node."""
+    functions: List[Dict[str, Any]] = []
+    classes: List[Dict[str, Any]] = []
+
+    for child in node.children:
+        if child.type in func_types:
+            functions.append({
+                "name": _node_name(child) or "<anonymous>",
+                "line_start": child.start_point[0] + 1,
+                "line_end": child.end_point[0] + 1,
+            })
+            # Recurse to catch nested functions/classes
+            sub_f, sub_c = _walk(child, func_types, class_types)
+            functions.extend(sub_f)
+            classes.extend(sub_c)
+        elif child.type in class_types:
+            classes.append({
+                "name": _node_name(child) or "<anonymous>",
+                "line_start": child.start_point[0] + 1,
+                "line_end": child.end_point[0] + 1,
+            })
+            sub_f, sub_c = _walk(child, func_types, class_types)
+            functions.extend(sub_f)
+            classes.extend(sub_c)
+        else:
+            sub_f, sub_c = _walk(child, func_types, class_types)
+            functions.extend(sub_f)
+            classes.extend(sub_c)
+
+    return functions, classes
+
+
+def parse_file(source: str, language: str) -> Optional[Dict[str, Any]]:
+    """Parse source code and extract functions/classes using tree-sitter.
+
+    Returns a dict with the same shape as ast_parser.parse_python_file(), or
+    None if tree-sitter or the language grammar is not available.
+    """
+    parser, func_types, class_types = _get_parser(language)
+    if parser is None:
+        return None
+
+    try:
+        tree = parser.parse(bytes(source, "utf-8"))
+        functions, classes = _walk(tree.root_node, func_types, class_types)
+
+        return {
+            "functions": functions,
+            "classes": classes,
+            "imports": [],
+            "line_count": len(source.splitlines()),
+            "error": None,
+        }
+    except Exception as exc:
+        logger.warning("tree-sitter parse failed for '%s': %s", language, exc)
+        return None


### PR DESCRIPTION
## Summary

- Removes the Python-only filter in the indexing pipeline — JS, TS, Go, Java, and Rust files in any uploaded or imported repository are now indexed
- New `treesitter_parser.py` service extracts functions and classes from non-Python files using tree-sitter language grammars; returns `None` gracefully when a grammar package is absent so callers can fall back
- `chunker.py` gains `chunk_file_multilang` (dispatch → tree-sitter → line-based fallback) and `_chunk_by_lines` (sliding-window fallback for unsupported languages)
- Python indexing path is unchanged

## Closes

Closes #49

## Changes

### `backend/services/treesitter_parser.py` (new)
- `_LANG_CONFIG`: maps language name → (package, factory function, function node types, class node types)
- `_get_parser(language)`: lazy-imports grammar package via `importlib`; returns `(None, None, None)` on `ImportError`
- `_node_name(node)`: tries `child_by_field_name("name")` first, falls back to first identifier child
- `_walk(node, func_types, class_types)`: recursive DFS over parse tree
- `parse_file(source, language)`: public API — same return shape as `parse_python_file()`

### `backend/services/chunker.py`
- `chunk_file_multilang(source, file_path, language)`: Python → `chunk_file`; other → `_chunks_from_parsed` or `_chunk_by_lines`
- `_chunks_from_parsed`: assembles chunks from tree-sitter result using existing `_create_chunk` / `_split_large_chunks`
- `_chunk_by_lines`: line-based sliding window with overlap — used when tree-sitter is unavailable or finds no symbols
- `chunk_directory`: updated to use `chunk_file_multilang`

### `backend/services/processor.py`
- Removed `if file_info["language"] != "python": continue`
- Calls `chunk_file_multilang(content, relative_path, language)` per file

### `backend/requirements.txt`
- `tree-sitter>=0.21.0` + grammars: python, javascript, typescript, go, java, rust

## Test Plan

- [ ] All 41 tests pass (`pytest backend/tests/ -q`)
- [ ] Upload a ZIP with `.js` and `.ts` files → chunks appear in MongoDB with correct `file_path`
- [ ] Upload a ZIP with `.go` or `.rs` files → functions extracted with correct line numbers
- [ ] Language not in config (e.g. `.php`) → line-based chunks created, no error
- [ ] Grammar package not installed → `_chunk_by_lines` fallback used, warning logged, no crash
- [ ] Python files in same repo → unchanged behavior, AST-extracted functions/classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)