### PR TITLE
Phase 6: LLM Response Streaming + Incremental Re-indexing

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -8,10 +8,12 @@ Phase 13: Added JWT authentication and rate limiting
 """
 
 from fastapi import APIRouter, HTTPException, status, Depends, Request
+from fastapi.responses import StreamingResponse
 from typing import Optional, List
 from pydantic import BaseModel
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+import json
 
 from backend.services.chat_service import ChatService
 from backend.services.rag_pipeline import RAGPipeline
@@ -283,6 +285,57 @@ async def chat_query(
         "session_id": session_id,
         "status": result.get("status", "unknown")
     }
+
+
+@router.post("/query/stream")
+@limiter.limit("10/minute")
+async def chat_query_stream(
+    request: Request,
+    chat_request: ChatQueryRequest,
+    current_user: dict = Depends(get_current_user)
+):
+    """POST /chat/query/stream — SSE streaming answer.
+
+    Streams LLM tokens as Server-Sent Events. Each event is a JSON object:
+      {"type": "token", "token": "...", "answer": "<accumulated>"}
+      {"type": "done",  "answer": "<full>", "sources": [...], "chunks_used": N}
+      {"type": "error", "answer": "...", "error": "..."}
+
+    Session messages are persisted after the "done" event.
+    """
+    session_id = chat_request.session_id
+
+    if session_id:
+        session = await ChatService.get_session(session_id)
+        if not session:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Session with id '{session_id}' not found"
+            )
+        if session.get("user_id") and session["user_id"] != current_user.get("user_id"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have access to this session"
+            )
+
+    async def event_generator():
+        full_answer = ""
+        async for event in rag_pipeline.query_with_streaming(
+            question=chat_request.question,
+            repository_id=chat_request.repository_id,
+            limit=chat_request.limit,
+            session_id=session_id,
+        ):
+            if event.get("type") == "token":
+                full_answer = event.get("answer", full_answer)
+            elif event.get("type") == "done":
+                full_answer = event.get("answer", full_answer)
+                if session_id:
+                    await ChatService.add_message(session_id, "user", chat_request.question)
+                    await ChatService.add_message(session_id, "assistant", full_answer)
+            yield f"data: {json.dumps(event)}\n\n"
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
 @router.get("/sessions")

--- a/backend/api/repositories.py
+++ b/backend/api/repositories.py
@@ -222,6 +222,64 @@ async def upload_repository(
         }
 
 
+@router.post("/{repo_id}/reindex", status_code=status.HTTP_200_OK)
+@limiter.limit("5/minute")
+async def reindex_repository(
+    request: Request,
+    repo_id: str,
+    file: UploadFile = File(...),
+    current_user: dict = Depends(get_current_user)
+):
+    """Re-index a repository from a new ZIP, updating only changed files.
+
+    Computes MD5 content hashes and skips files whose hash matches the
+    stored value. Only changed and new files are re-embedded; chunks for
+    removed files are deleted. Rate limit: 5 requests per minute.
+    """
+    if not file.filename.endswith(".zip"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only ZIP files are accepted"
+        )
+
+    db = Database.get_db()
+    user_id = current_user.get("user_id")
+
+    try:
+        repo = await db.repositories.find_one({"_id": ObjectId(repo_id)})
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid repository ID format")
+
+    if not repo:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Repository '{repo_id}' not found")
+
+    if repo.get("user_id") and repo["user_id"] != user_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You do not have access to this repository")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        zip_path = os.path.join(temp_dir, file.filename)
+        with open(zip_path, "wb") as f:
+            shutil.copyfileobj(file.file, f)
+
+        with zipfile.ZipFile(zip_path, "r") as zip_ref:
+            zip_ref.extractall(temp_dir)
+
+        root_content = os.listdir(temp_dir)
+        extract_base = temp_dir
+        if len(root_content) == 1 and os.path.isdir(os.path.join(temp_dir, root_content[0])):
+            extract_base = os.path.join(temp_dir, root_content[0])
+
+        processor = RepositoryProcessor()
+        result = await processor.process_repository_incremental(repo_id, extract_base)
+
+    await db.repositories.update_one(
+        {"_id": ObjectId(repo_id)},
+        {"$set": {"updated_at": datetime.now()}}
+    )
+
+    return {"repository_id": repo_id, **result}
+
+
 @router.put("/{repo_id}", response_model=RepositoryResponse)
 @limiter.limit("20/minute")
 async def update_repository(

--- a/backend/services/processor.py
+++ b/backend/services/processor.py
@@ -3,6 +3,7 @@ from backend.services.file_scanner import scan_directory, get_file_content
 from backend.services.chunker import CodeChunker
 from backend.services.vector_store import VectorStore
 from typing import Dict, Any, Optional
+import hashlib
 import os
 from datetime import datetime
 
@@ -41,9 +42,12 @@ class RepositoryProcessor:
         for file_info in files:
             content = get_file_content(file_info["path"])
             if content:
+                file_hash = hashlib.md5(content.encode("utf-8", errors="replace")).hexdigest()
                 chunks = self.chunker.chunk_file_multilang(
                     content, file_info["relative_path"], file_info["language"]
                 )
+                for chunk in chunks:
+                    chunk["file_hash"] = file_hash
                 all_chunks.extend(chunks)
         
         if not all_chunks:
@@ -78,6 +82,89 @@ class RepositoryProcessor:
         
         return await self.process_repository(repository_id, local_path)
     
+    async def process_repository_incremental(
+        self, repository_id: str, local_path: str
+    ) -> Dict[str, Any]:
+        """Re-index only files whose content hash changed since the last indexing run.
+
+        Compares MD5 hashes of current files against hashes stored in chunk metadata.
+        Deletes stale chunks for changed or removed files, then re-embeds only the
+        changed/new ones. Unchanged files are skipped entirely.
+        """
+        db = Database.get_db()
+
+        # Collect existing (file_path, file_hash) pairs from stored chunks
+        existing_chunks = await db.chunks.find(
+            {"repository_id": repository_id},
+            {"metadata.file_path": 1, "metadata.file_hash": 1}
+        ).to_list(None)
+
+        existing_hashes: Dict[str, str] = {}
+        for chunk in existing_chunks:
+            meta = chunk.get("metadata", {})
+            fp = meta.get("file_path", "")
+            fh = meta.get("file_hash", "")
+            if fp and fh:
+                existing_hashes[fp] = fh
+
+        # Compute hashes for current files
+        files = scan_directory(local_path)
+        new_hashes: Dict[str, str] = {}
+        file_info_map: Dict[str, Any] = {}
+        for file_info in files:
+            content = get_file_content(file_info["path"])
+            if content:
+                new_hashes[file_info["relative_path"]] = hashlib.md5(
+                    content.encode("utf-8", errors="replace")
+                ).hexdigest()
+                file_info_map[file_info["relative_path"]] = (file_info, content)
+
+        # Determine which files changed or were removed
+        changed = {fp for fp, fh in new_hashes.items() if existing_hashes.get(fp) != fh}
+        removed = set(existing_hashes.keys()) - set(new_hashes.keys())
+        stale = changed | removed
+
+        if stale:
+            await db.chunks.delete_many({
+                "repository_id": repository_id,
+                "metadata.file_path": {"$in": list(stale)}
+            })
+
+        if not changed:
+            return {
+                "status": "success",
+                "message": "No file changes detected — index is up to date",
+                "files_changed": 0,
+                "files_removed": len(removed),
+                "chunks_created": 0
+            }
+
+        all_chunks = []
+        for rel_path in changed:
+            if rel_path not in file_info_map:
+                continue
+            file_info, content = file_info_map[rel_path]
+            file_hash = new_hashes[rel_path]
+            chunks = self.chunker.chunk_file_multilang(
+                content, rel_path, file_info["language"]
+            )
+            for chunk in chunks:
+                chunk["file_hash"] = file_hash
+            all_chunks.extend(chunks)
+
+        chunks_added = 0
+        if all_chunks:
+            await self.vector_store.ensure_indexes()
+            chunks_added = await self.vector_store.add_chunks(all_chunks, repository_id)
+
+        return {
+            "status": "success",
+            "message": f"Re-indexed {len(changed)} changed file(s), removed {len(removed)} deleted file(s)",
+            "files_changed": len(changed),
+            "files_removed": len(removed),
+            "chunks_created": chunks_added
+        }
+
     async def delete_repository_data(self, repository_id: str) -> int:
         """Delete all data associated with a repository
         

--- a/backend/services/vector_store.py
+++ b/backend/services/vector_store.py
@@ -60,7 +60,8 @@ class VectorStore:
                     "name": chunk.get("name", ""),
                     "start_line": chunk.get("start_line", 0),
                     "end_line": chunk.get("end_line", 0),
-                    "token_count": chunk.get("token_count", 0)
+                    "token_count": chunk.get("token_count", 0),
+                    "file_hash": chunk.get("file_hash", "")
                 }
             })
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,10 @@ function App() {
   const [uploadFile, setUploadFile] = useState(null)
   const [uploadStatus, setUploadStatus] = useState('')
 
+  // Reindex state
+  const [reindexFile, setReindexFile] = useState(null)
+  const [reindexStatus, setReindexStatus] = useState('')
+
   // GitHub import state
   const [githubUrl, setGithubUrl] = useState('')
   const [importStatus, setImportStatus] = useState('')
@@ -145,6 +149,27 @@ function App() {
     }
   }
 
+  const handleReindex = async () => {
+    if (!reindexFile || !selectedRepo) return
+    setLoading(true)
+    setReindexStatus('Re-indexing...')
+    const formData = new FormData()
+    formData.append('file', reindexFile)
+    try {
+      const res = await axios.post(`${API_URL}/repositories/${selectedRepo}/reindex`, formData, {
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'multipart/form-data' }
+      })
+      const { files_changed, files_removed, chunks_created } = res.data
+      setReindexStatus(`Done — ${files_changed} changed, ${files_removed} removed, ${chunks_created} new chunks`)
+      setReindexFile(null)
+    } catch (err) {
+      setReindexStatus('Failed: ' + (err.response?.data?.detail || err.message))
+    } finally {
+      setLoading(false)
+      setTimeout(() => setReindexStatus(''), 5000)
+    }
+  }
+
   // ── Sessions ──────────────────────────────────────────────────────────────
 
   const fetchSessions = async (repoId) => {
@@ -232,34 +257,62 @@ function App() {
     setQuestion('')
     setLoading(true)
 
-    // Optimistically add the user message to chat
-    setChatHistory(prev => [...prev, { role: 'user', content: userMessage, timestamp: new Date().toISOString() }])
+    // Add user message and an empty assistant placeholder
+    const assistantPlaceholder = { role: 'assistant', content: '', sources: [], timestamp: new Date().toISOString() }
+    setChatHistory(prev => [
+      ...prev,
+      { role: 'user', content: userMessage, timestamp: new Date().toISOString() },
+      assistantPlaceholder
+    ])
 
     try {
-      const res = await axios.post(`${API_URL}/chat/query`, {
-        question: userMessage,
-        repository_id: selectedRepo,
-        session_id: sessionId,
-        limit: 5
-      }, {
-        headers: { Authorization: `Bearer ${token}` }
+      const response = await fetch(`${API_URL}/chat/query/stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ question: userMessage, repository_id: selectedRepo, session_id: sessionId, limit: 5 })
       })
 
-      const assistantMessage = {
-        role: 'assistant',
-        content: res.data.answer,
-        sources: res.data.sources,
-        chunks_found: res.data.chunks_found,
-        timestamp: new Date().toISOString()
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}))
+        throw new Error(err.detail || response.statusText)
       }
-      setChatHistory(prev => [...prev, assistantMessage])
-      fetchSessions(selectedRepo)
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop()   // keep incomplete line for next iteration
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          try {
+            const event = JSON.parse(line.slice(6))
+            if (event.type === 'token' || event.type === 'done') {
+              setChatHistory(prev => {
+                const updated = [...prev]
+                updated[updated.length - 1] = {
+                  ...updated[updated.length - 1],
+                  content: event.answer,
+                  sources: event.sources || updated[updated.length - 1].sources
+                }
+                return updated
+              })
+            }
+            if (event.type === 'done') fetchSessions(selectedRepo)
+          } catch { /* malformed line — skip */ }
+        }
+      }
     } catch (err) {
-      setChatHistory(prev => [...prev, {
-        role: 'assistant',
-        content: 'Error: ' + (err.response?.data?.detail || err.message),
-        timestamp: new Date().toISOString()
-      }])
+      setChatHistory(prev => {
+        const updated = [...prev]
+        updated[updated.length - 1] = { ...updated[updated.length - 1], content: 'Error: ' + err.message }
+        return updated
+      })
     } finally {
       setLoading(false)
     }
@@ -380,6 +433,22 @@ function App() {
               ))}
             </select>
           </section>
+
+          {selectedRepo && (
+            <section className="upload-section">
+              <h2>Re-index Repository</h2>
+              <div className="upload-form">
+                <input
+                  type="file"
+                  accept=".zip"
+                  onChange={(e) => setReindexFile(e.target.files[0])}
+                />
+                <button onClick={handleReindex} disabled={loading || !reindexFile}>
+                  {reindexStatus || 'Re-index ZIP'}
+                </button>
+              </div>
+            </section>
+          )}
 
           {selectedRepo && (
             <section className="sessions-section">


### PR DESCRIPTION
## Summary

- **Streaming**: LLM tokens stream to the browser as they're generated — no more waiting for the full answer before seeing anything. Uses SSE on the backend and the Fetch `ReadableStream` API on the frontend.
- **Incremental re-indexing**: Re-uploading a repository only re-embeds files whose MD5 content hash changed. Unchanged files are skipped; deleted files have their chunks removed. Reduces embedding API cost on iterative updates.

## Closes

Closes #51

## Changes

### `backend/api/chat.py`
- `POST /chat/query/stream`: `StreamingResponse(text/event-stream)`, rate limit 10/min
- Each yielded event from `RAGPipeline.query_with_streaming` serialized as `data: {json}\n\n`
- Session messages persisted after `type=done` event

### `backend/services/vector_store.py`
- `file_hash` added to chunk metadata in `add_chunks`

### `backend/services/processor.py`
- `process_repository`: computes MD5 of each file before chunking; stores hash in chunk
- `process_repository_incremental`: loads existing hashes from MongoDB, diffs against new scan, deletes stale chunks, re-embeds only changed/new files

### `backend/api/repositories.py`
- `POST /repositories/{id}/reindex`: ZIP upload, runs incremental processor, updates `updated_at`; rate limit 5/min; ownership check

### `frontend/src/App.jsx`
- `askQuestion`: rewritten to use `fetch` + `ReadableStream`; adds empty assistant placeholder immediately, updates content on each `token` event, populates sources on `done`
- SSE line buffer handles partial chunks across read boundaries
- State: `reindexFile`, `reindexStatus`; handler: `handleReindex`
- UI: "Re-index Repository" section in sidebar (visible when repo selected); shows diff summary on completion

## Test Plan

- [ ] All 41 tests pass (`pytest backend/tests/ -q`)
- [ ] Chat response tokens appear incrementally in the UI
- [ ] Session history populated after streaming completes
- [ ] Re-index with identical ZIP → `files_changed: 0`, no new embeddings
- [ ] Re-index with modified file → only that file's chunks recreated
- [ ] Re-index with file removed from ZIP → orphaned chunks deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)