### PR TITLE
refactor: LLM/embedding provider abstraction layer + singleton service pattern

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,24 +1,55 @@
-# OpenAI API Key
+# ── LLM Provider ────────────────────────────────────────────────────────────
+# Which LLM provider to use for answer generation.
+# Supported: openai (default), anthropic
+LLM_PROVIDER=openai
+
+# Model name for the selected LLM provider.
+# OpenAI options:    gpt-4o-mini (default), gpt-4o, gpt-4
+# Anthropic options: claude-sonnet-4-6, claude-haiku-4-5-20251001, claude-opus-4-7
+LLM_MODEL=gpt-4o-mini
+
+# Maximum tokens in LLM response (default: 2000)
+LLM_MAX_TOKENS=2000
+
+# ── Embedding Provider ───────────────────────────────────────────────────────
+# Which provider to use for generating vector embeddings.
+# Supported: openai (default; Anthropic has no embedding API)
+EMBEDDING_PROVIDER=openai
+
+# Model name for the selected embedding provider.
+# OpenAI options: text-embedding-3-small (default), text-embedding-3-large
+EMBEDDING_MODEL=text-embedding-3-small
+
+# ── API Keys ─────────────────────────────────────────────────────────────────
+# Required when LLM_PROVIDER=openai or EMBEDDING_PROVIDER=openai
 OPENAI_API_KEY=
 
-# MongoDB Atlas Connection
-MONGODB_URI=mongodb+srv://<username>:<password>@cluster0.<cluster>.mongodb.net/ragdb?retryWrites=true&w=majority
+# Required when LLM_PROVIDER=anthropic
+# Get key at: https://console.anthropic.com
+ANTHROPIC_API_KEY=
 
-# GitHub OAuth (optional)
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
-
-# JWT Secret (generate strong secret for production)
-JWT_SECRET=your-super-secret-key-change-in-production
-
-# CORS origins (comma-separated)
-ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
-
-# Cohere API key — enables cross-encoder re-ranking after RRF fusion
-# Free tier: 1,000 requests/month. Get key at https://cohere.com
-# Optional: omit to use heuristic re-ranking fallback
+# Optional — enables Cohere cross-encoder re-ranking after RRF fusion.
+# Free tier: 1,000 requests/month. Get key at: https://cohere.com
+# Omit or leave blank to use heuristic re-ranking fallback.
 COHERE_API_KEY=
 
-# LLM model override (default: gpt-4o-mini)
-# Options: gpt-4o-mini, gpt-4o, gpt-4
-LLM_MODEL=
+# ── Database ─────────────────────────────────────────────────────────────────
+# MongoDB Atlas connection string.
+# Get from Atlas UI: Database > Connect > Drivers
+MONGODB_URI=mongodb+srv://<username>:<password>@cluster0.<cluster>.mongodb.net/ragdb?retryWrites=true&w=majority
+
+# ── Auth ─────────────────────────────────────────────────────────────────────
+# JWT signing secret — use a long random string in production.
+# Generate: python -c "import secrets; print(secrets.token_hex(32))"
+JWT_SECRET=your-super-secret-key-change-in-production
+
+# ── CORS ─────────────────────────────────────────────────────────────────────
+# Comma-separated list of allowed frontend origins.
+ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+# ── GitHub (optional) ────────────────────────────────────────────────────────
+# Personal access token for importing private GitHub repositories.
+# Required scope: repo (read-only)
+# Create at: https://github.com/settings/tokens
+# Leave blank for public repositories only.
+GITHUB_TOKEN=

--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -225,9 +225,6 @@ async def get_session_history(
     }
 
 
-rag_pipeline = RAGPipeline()
-
-
 @router.post("/query", response_model=ChatQueryResponse)
 @limiter.limit("10/minute")
 async def chat_query(
@@ -259,6 +256,7 @@ async def chat_query(
                 detail="You do not have access to this session"
             )
 
+    rag_pipeline: RAGPipeline = request.app.state.rag_pipeline
     result = await rag_pipeline.query(
         question=chat_request.question,
         repository_id=chat_request.repository_id,
@@ -317,6 +315,8 @@ async def chat_query_stream(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="You do not have access to this session"
             )
+
+    rag_pipeline: RAGPipeline = request.app.state.rag_pipeline
 
     async def event_generator():
         full_answer = ""

--- a/backend/api/repositories.py
+++ b/backend/api/repositories.py
@@ -209,9 +209,9 @@ async def upload_repository(
         result = await db.repositories.insert_one(doc)
         repo_id = str(result.inserted_id)
         
-        processor = RepositoryProcessor()
+        processor: RepositoryProcessor = request.app.state.processor
         processing_result = await processor.process_repository(repo_id, extract_base)
-        
+
         return {
             "id": repo_id,
             "name": doc["name"],
@@ -269,7 +269,7 @@ async def reindex_repository(
         if len(root_content) == 1 and os.path.isdir(os.path.join(temp_dir, root_content[0])):
             extract_base = os.path.join(temp_dir, root_content[0])
 
-        processor = RepositoryProcessor()
+        processor: RepositoryProcessor = request.app.state.processor
         result = await processor.process_repository_incremental(repo_id, extract_base)
 
     await db.repositories.update_one(
@@ -390,7 +390,7 @@ async def delete_repository(
             detail="You do not have access to delete this repository"
         )
 
-    processor = RepositoryProcessor()
+    processor: RepositoryProcessor = request.app.state.processor
     await processor.delete_repository_data(repo_id)
 
     await db.repositories.delete_one({"_id": ObjectId(repo_id)})
@@ -452,7 +452,7 @@ async def search_symbols(
             detail="name query parameter is required"
         )
 
-    keyword_service = KeywordSearchService()
+    keyword_service: KeywordSearchService = request.app.state.keyword_service
 
     symbol_type = (type or "").lower()
 
@@ -517,7 +517,7 @@ async def get_repository_stats(
             detail="You do not have access to this repository"
         )
 
-    processor = RepositoryProcessor()
+    processor: RepositoryProcessor = request.app.state.processor
     stats = await processor.get_repository_stats(repo_id)
 
     return {
@@ -600,7 +600,7 @@ async def import_repository(
         repo_id = str(result.inserted_id)
 
         try:
-            processor = RepositoryProcessor()
+            processor: RepositoryProcessor = request.app.state.processor
             processing_result = await processor.process_repository(repo_id, clone_path)
         except Exception as exc:
             await db.repositories.delete_one({"_id": result.inserted_id})

--- a/backend/main.py
+++ b/backend/main.py
@@ -32,17 +32,24 @@ async def lifespan(app: FastAPI):
     
     from backend.services.vector_store import VectorStore
     from backend.services.keyword_search import KeywordSearchService
-    
+    from backend.services.processor import RepositoryProcessor
+    from backend.services.rag_pipeline import RAGPipeline
+
     vector_store = VectorStore()
     await vector_store.ensure_indexes()
-    
+
     keyword_search = KeywordSearchService()
     await keyword_search.ensure_indexes()
-    
-    print("Indexes initialized")
-    
+
+    # Shared singletons — one API client / connection pool per service type
+    app.state.processor = RepositoryProcessor()
+    app.state.keyword_service = keyword_search
+    app.state.rag_pipeline = RAGPipeline()
+
+    print("Indexes and services initialized")
+
     yield
-    
+
     await Database.disconnect()
     print("Disconnected from MongoDB")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ bcrypt==4.0.1
 slowapi==0.1.9
 numpy==2.2.2
 cohere>=5.0.0
+anthropic>=0.27.0
 tree-sitter>=0.21.0
 tree-sitter-python
 tree-sitter-javascript

--- a/backend/services/embedding.py
+++ b/backend/services/embedding.py
@@ -1,96 +1,58 @@
-import asyncio
-import logging
-from openai import AsyncOpenAI, RateLimitError, APIStatusError
-from typing import List
+"""EmbeddingService — thin wrapper around the configured EmbeddingProvider.
+
+Provider is selected via environment variable:
+  EMBEDDING_PROVIDER=openai   (default; only supported option currently)
+  EMBEDDING_MODEL=text-embedding-3-small
+
+Switching provider in the future requires only .env changes.
+"""
 import os
+from typing import List, Optional
 
-logger = logging.getLogger(__name__)
-
-_BATCH_SIZE = 2000
-_MAX_RETRIES = 3
+from backend.services.providers.base import EmbeddingProvider
+from backend.services.providers.factory import get_embedding_provider
 
 
 class EmbeddingService:
-    """Handles OpenAI embedding generation with batching and retry."""
+    """Public API for generating embeddings — delegates to EmbeddingProvider."""
 
-    def __init__(self):
-        api_key = os.getenv("OPENAI_API_KEY")
-        if not api_key:
-            raise ValueError("OPENAI_API_KEY not set in .env")
+    def __init__(self, provider: Optional[EmbeddingProvider] = None):
+        self._provider = provider or get_embedding_provider()
 
-        self.client = AsyncOpenAI(api_key=api_key)
-        self.model = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
-        self.dimensions = 1536
-
-    async def _embed_batch_with_retry(self, batch: List[str]) -> List[List[float]]:
-        """Send one batch to the OpenAI API with exponential-backoff retry."""
-        delay = 1.0
-        for attempt in range(1, _MAX_RETRIES + 1):
-            try:
-                response = await self.client.embeddings.create(
-                    model=self.model,
-                    input=batch,
-                    encoding_format="float",
-                )
-                return [item.embedding for item in response.data]
-            except RateLimitError:
-                if attempt == _MAX_RETRIES:
-                    raise
-                logger.warning(
-                    "Embedding rate-limited (attempt %d/%d), retrying in %.1fs",
-                    attempt, _MAX_RETRIES, delay,
-                )
-                await asyncio.sleep(delay)
-                delay *= 2
-            except APIStatusError as exc:
-                if exc.status_code >= 500 and attempt < _MAX_RETRIES:
-                    logger.warning(
-                        "Embedding API error %d (attempt %d/%d), retrying in %.1fs",
-                        exc.status_code, attempt, _MAX_RETRIES, delay,
-                    )
-                    await asyncio.sleep(delay)
-                    delay *= 2
-                else:
-                    raise
-        return []
+    @property
+    def dimensions(self) -> int:
+        return self._provider.dimensions
 
     async def generate_embedding(self, text: str) -> List[float]:
         """Generate embedding for a single text."""
-        results = await self._embed_batch_with_retry([text])
-        return results[0]
+        return await self._provider.embed_one(text)
 
     async def generate_embeddings(self, texts: List[str]) -> List[List[float]]:
         """Generate embeddings for an arbitrary number of texts.
 
-        Splits input into batches of at most 2,000 (OpenAI API limit) and
-        retries each batch independently on rate-limit or server errors.
+        Batching and retry are handled by the underlying provider.
         """
-        if not texts:
-            return []
-
-        all_embeddings: List[List[float]] = []
-        for i in range(0, len(texts), _BATCH_SIZE):
-            batch = texts[i: i + _BATCH_SIZE]
-            logger.debug(
-                "Embedding batch %d-%d of %d texts",
-                i + 1, i + len(batch), len(texts),
-            )
-            embeddings = await self._embed_batch_with_retry(batch)
-            all_embeddings.extend(embeddings)
-
-        return all_embeddings
+        return await self._provider.embed_batch(texts)
 
     async def generate_embedding_with_dimensions(
         self, text: str, dimensions: int = 1536
     ) -> List[float]:
-        """Generate embedding with custom dimensions.
+        """Generate embedding with custom dimensions (OpenAI provider only).
 
-        text-embedding-3-small supports 256–3072 dimensions.
+        Falls back to standard embedding if the provider does not support
+        custom dimensions.
         """
-        response = await self.client.embeddings.create(
-            model=self.model,
-            input=text,
-            dimensions=dimensions,
-            encoding_format="float",
-        )
-        return response.data[0].embedding
+        from backend.services.providers.openai_provider import OpenAIEmbeddingProvider
+        if isinstance(self._provider, OpenAIEmbeddingProvider):
+            import os
+            from openai import AsyncOpenAI
+            client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+            model = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
+            response = await client.embeddings.create(
+                model=model,
+                input=text,
+                dimensions=dimensions,
+                encoding_format="float",
+            )
+            return response.data[0].embedding
+        return await self._provider.embed_one(text)

--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -1,56 +1,70 @@
-from openai import AsyncOpenAI, RateLimitError, APIError
-from typing import List, Dict, Any, AsyncIterator, Optional
+import logging
 import os
+from typing import AsyncIterator, Dict, Any, List, Optional
+
 from dotenv import load_dotenv
+from openai import RateLimitError, APIError
+
+from backend.services.providers.base import LLMProvider
+from backend.services.providers.factory import get_llm_provider
 
 load_dotenv()
 
+logger = logging.getLogger(__name__)
+
 
 class LLMService:
-    """Handles LLM interactions for answer generation"""
+    """Generates LLM answers for retrieved code context.
+
+    Delegates to a pluggable LLMProvider so that switching between
+    OpenAI and Anthropic Claude requires only .env changes:
+
+      LLM_PROVIDER=anthropic
+      LLM_MODEL=claude-sonnet-4-6
+      ANTHROPIC_API_KEY=sk-ant-...
+    """
 
     MAX_HISTORY_TOKENS = 2000
 
-    def __init__(self):
-        api_key = os.getenv("OPENAI_API_KEY")
-        if not api_key:
-            raise ValueError("OPENAI_API_KEY not set in environment variables")
+    _SYSTEM_PROMPT = (
+        "You are an expert code analyst specialising in understanding and "
+        "explaining software codebases.\n\n"
+        "When answering questions:\n"
+        "1. Cite specific file paths and line numbers for every claim\n"
+        "2. Include relevant code snippets from the provided context\n"
+        "3. If the answer is not in the context, clearly say so\n"
+        "4. Provide clear, actionable explanations\n"
+        "5. Use markdown formatting for readability\n"
+        "6. Focus on explaining HOW the code works, not just WHAT it does"
+    )
 
-        self.client = AsyncOpenAI(api_key=api_key)
-        self.model = os.getenv("LLM_MODEL", "gpt-4o-mini")
+    def __init__(self, provider: Optional[LLMProvider] = None):
+        self._provider = provider or get_llm_provider()
         self.temperature = 0.2
         self.max_tokens = int(os.getenv("LLM_MAX_TOKENS", "2000"))
 
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
     def _format_context(self, chunks: List[Dict[str, Any]]) -> str:
-        """Format retrieved code chunks for LLM context"""
-        context_parts = []
-
+        parts = []
         for i, chunk in enumerate(chunks, 1):
-            metadata = chunk.get("metadata", {})
-            file_path = metadata.get("file_path", "unknown")
-            start_line = metadata.get("start_line", 0)
-            end_line = metadata.get("end_line", 0)
-            chunk_type = metadata.get("chunk_type", "code")
-            name = metadata.get("name", "")
-
-            header = f"Source {i}: {file_path}:{start_line}-{end_line}"
-            if name:
-                header += f" ({chunk_type}: {name})"
-
-            context_parts.append(
-                f"--- {header} ---\n{chunk.get('content', '')}\n"
+            meta = chunk.get("metadata", {})
+            header = (
+                f"Source {i}: {meta.get('file_path', 'unknown')}"
+                f":{meta.get('start_line', 0)}-{meta.get('end_line', 0)}"
             )
-
-        return "\n".join(context_parts)
+            name = meta.get("name", "")
+            if name:
+                header += f" ({meta.get('chunk_type', 'code')}: {name})"
+            parts.append(f"--- {header} ---\n{chunk.get('content', '')}\n")
+        return "\n".join(parts)
 
     def _truncate_history(
         self, history: List[Dict[str, Any]]
     ) -> List[Dict[str, Any]]:
-        """Return the most recent history entries that fit within MAX_HISTORY_TOKENS.
-
-        Removes from the oldest end until the total token count is within budget.
-        Always removes pairs (user + assistant) to keep the conversation coherent.
-        """
+        """Return the most recent history entries within MAX_HISTORY_TOKENS."""
         if not history:
             return []
 
@@ -65,42 +79,23 @@ class LLMService:
 
         truncated = list(history)
         while truncated and token_count(truncated) > self.MAX_HISTORY_TOKENS:
-            # Drop the oldest pair to preserve conversation coherence
             truncated = truncated[2:] if len(truncated) >= 2 else truncated[1:]
-
         return truncated
 
-    def _build_prompt(
+    def _build_messages(
         self,
         query: str,
         context: str,
-        chat_history: Optional[List[Dict[str, Any]]] = None
+        chat_history: Optional[List[Dict[str, Any]]] = None,
     ) -> List[Dict[str, str]]:
-        """Build the messages array for the LLM API call.
+        """Build the conversation messages array (without system prompt).
 
-        History is passed as native alternating user/assistant turns so the
-        model uses its fine-tuned multi-turn attention rather than parsing
-        injected text. History is truncated to MAX_HISTORY_TOKENS from the
-        oldest end before inclusion.
+        History is passed as native alternating user/assistant turns.
+        The final user turn contains the retrieved context and the query.
         """
-        system_prompt = (
-            "You are an expert code analyst specialising in understanding and "
-            "explaining software codebases.\n\n"
-            "When answering questions:\n"
-            "1. Cite specific file paths and line numbers for every claim\n"
-            "2. Include relevant code snippets from the provided context\n"
-            "3. If the answer is not in the context, clearly say so\n"
-            "4. Provide clear, actionable explanations\n"
-            "5. Use markdown formatting for readability\n"
-            "6. Focus on explaining HOW the code works, not just WHAT it does"
-        )
+        messages: List[Dict[str, str]] = []
 
-        messages: List[Dict[str, str]] = [
-            {"role": "system", "content": system_prompt}
-        ]
-
-        truncated_history = self._truncate_history(chat_history or [])
-        for msg in truncated_history:
+        for msg in self._truncate_history(chat_history or []):
             role = msg.get("role", "user")
             if role not in ("user", "assistant"):
                 continue
@@ -116,26 +111,18 @@ class LLMService:
             "you can explain from the available context."
         )
         messages.append({"role": "user", "content": user_content})
-
         return messages
 
     def _validate_citations(
         self,
         answer: str,
-        retrieved_chunks: List[Dict[str, Any]]
+        retrieved_chunks: List[Dict[str, Any]],
     ) -> Dict[str, Any]:
-        """Validate that file paths cited in the answer exist in retrieved chunks.
-
-        Extracts all .py paths from the answer text and checks each against
-        the file_path metadata of the chunks that were actually retrieved.
-        Returns a dict with citation_valid flag and list of unverified paths.
-        """
+        """Check that file paths cited in the answer appear in retrieved chunks."""
         import re
 
         _INDEXED_EXTENSIONS = r'\.(?:py|js|ts|jsx|tsx|go|java|rs|rb)'
-        cited_files = set(re.findall(
-            r'[\w/._-]+' + _INDEXED_EXTENSIONS, answer
-        ))
+        cited_files = set(re.findall(r'[\w/._-]+' + _INDEXED_EXTENSIONS, answer))
 
         source_paths = {
             chunk.get("metadata", {}).get("file_path", "")
@@ -147,146 +134,135 @@ class LLMService:
             f for f in cited_files
             if f not in source_paths and f.split("/")[-1] not in source_basenames
         ]
-
         return {
             "cited_files": sorted(cited_files),
             "hallucinated_files": hallucinated,
-            "citation_valid": len(hallucinated) == 0
+            "citation_valid": len(hallucinated) == 0,
         }
+
+    def _build_sources(
+        self, retrieved_chunks: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        sources = []
+        for chunk in retrieved_chunks:
+            meta = chunk.get("metadata", {})
+            sources.append({
+                "file_path": meta.get("file_path", ""),
+                "start_line": meta.get("start_line", 0),
+                "end_line": meta.get("end_line", 0),
+                "chunk_type": meta.get("chunk_type", "code"),
+                "name": meta.get("name", ""),
+                "score": chunk.get("final_score", chunk.get("hybrid_score", 0)),
+            })
+        return sources
+
+    def _append_citation_warning(
+        self, answer: str, citation_check: Dict[str, Any]
+    ) -> str:
+        if citation_check["hallucinated_files"]:
+            unverified = ", ".join(
+                f"`{f}`" for f in citation_check["hallucinated_files"]
+            )
+            answer += (
+                f"\n\n> **Note**: The following file references could not be "
+                f"verified against the indexed source: {unverified}"
+            )
+        return answer
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     async def generate_answer(
         self,
         query: str,
         retrieved_chunks: List[Dict[str, Any]],
-        chat_history: Optional[List[Dict[str, Any]]] = None
+        chat_history: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
-        """Generate answer from retrieved context"""
-
+        """Generate a complete answer from retrieved context."""
         if not retrieved_chunks:
             return {
-                "answer": "No relevant code found for your question. Try rephrasing or asking about a different aspect of the codebase.",
-                "sources": []
+                "answer": (
+                    "No relevant code found for your question. "
+                    "Try rephrasing or asking about a different aspect of the codebase."
+                ),
+                "sources": [],
             }
 
         try:
             context = self._format_context(retrieved_chunks)
-            messages = self._build_prompt(query, context, chat_history)
+            messages = self._build_messages(query, context, chat_history)
 
-            response = await self.client.chat.completions.create(
-                model=self.model,
+            answer = await self._provider.complete(
+                system=self._SYSTEM_PROMPT,
                 messages=messages,
+                max_tokens=self.max_tokens,
                 temperature=self.temperature,
-                max_tokens=self.max_tokens
             )
 
-            answer = response.choices[0].message.content
-
             citation_check = self._validate_citations(answer, retrieved_chunks)
-            if citation_check["hallucinated_files"]:
-                unverified = ", ".join(f"`{f}`" for f in citation_check["hallucinated_files"])
-                answer += (
-                    f"\n\n> **Note**: The following file references could not be "
-                    f"verified against the indexed source: {unverified}"
-                )
-
-            sources = []
-            for chunk in retrieved_chunks:
-                metadata = chunk.get("metadata", {})
-                sources.append({
-                    "file_path": metadata.get("file_path", ""),
-                    "start_line": metadata.get("start_line", 0),
-                    "end_line": metadata.get("end_line", 0),
-                    "chunk_type": metadata.get("chunk_type", "code"),
-                    "name": metadata.get("name", ""),
-                    "score": chunk.get("final_score", chunk.get("hybrid_score", 0))
-                })
+            answer = self._append_citation_warning(answer, citation_check)
 
             return {
                 "answer": answer,
-                "sources": sources,
+                "sources": self._build_sources(retrieved_chunks),
                 "chunks_used": len(retrieved_chunks),
                 "citation_valid": citation_check["citation_valid"],
-                "citation_warnings": citation_check["hallucinated_files"]
+                "citation_warnings": citation_check["hallucinated_files"],
             }
 
         except RateLimitError:
             return {
                 "answer": "Rate limit reached. Please wait a moment and try again.",
                 "sources": [],
-                "error": "rate_limit"
+                "error": "rate_limit",
             }
         except APIError as e:
             return {
-                "answer": f"API error occurred: {str(e)}",
+                "answer": f"API error occurred: {e}",
                 "sources": [],
-                "error": "api_error"
+                "error": "api_error",
             }
         except Exception as e:
+            logger.error("LLM generation error: %s", e)
             return {
-                "answer": f"Error generating answer: {str(e)}",
+                "answer": f"Error generating answer: {e}",
                 "sources": [],
-                "error": "unknown"
+                "error": "unknown",
             }
 
     async def generate_streaming_answer(
         self,
         query: str,
         retrieved_chunks: List[Dict[str, Any]],
-        chat_history: Optional[List[Dict[str, Any]]] = None
+        chat_history: Optional[List[Dict[str, Any]]] = None,
     ) -> AsyncIterator[Dict[str, Any]]:
-        """Generate answer with streaming responses"""
-
+        """Generate an answer with streaming token events."""
         if not retrieved_chunks:
             yield {
                 "type": "done",
                 "answer": "No relevant code found for your question.",
-                "sources": []
+                "sources": [],
             }
             return
 
         try:
             context = self._format_context(retrieved_chunks)
-            messages = self._build_prompt(query, context, chat_history)
-
-            stream = await self.client.chat.completions.create(
-                model=self.model,
-                messages=messages,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-                stream=True
-            )
-
-            sources = []
-            for chunk in retrieved_chunks:
-                metadata = chunk.get("metadata", {})
-                sources.append({
-                    "file_path": metadata.get("file_path", ""),
-                    "start_line": metadata.get("start_line", 0),
-                    "end_line": metadata.get("end_line", 0),
-                    "chunk_type": metadata.get("chunk_type", "code"),
-                    "name": metadata.get("name", ""),
-                    "score": chunk.get("final_score", chunk.get("hybrid_score", 0))
-                })
+            messages = self._build_messages(query, context, chat_history)
+            sources = self._build_sources(retrieved_chunks)
 
             full_answer = ""
-
-            async for chunk in stream:
-                if chunk.choices[0].delta.content:
-                    token = chunk.choices[0].delta.content
-                    full_answer += token
-                    yield {
-                        "type": "token",
-                        "token": token,
-                        "answer": full_answer
-                    }
+            async for token in self._provider.stream(
+                system=self._SYSTEM_PROMPT,
+                messages=messages,
+                max_tokens=self.max_tokens,
+                temperature=self.temperature,
+            ):
+                full_answer += token
+                yield {"type": "token", "token": token, "answer": full_answer}
 
             citation_check = self._validate_citations(full_answer, retrieved_chunks)
-            if citation_check["hallucinated_files"]:
-                unverified = ", ".join(f"`{f}`" for f in citation_check["hallucinated_files"])
-                full_answer += (
-                    f"\n\n> **Note**: The following file references could not be "
-                    f"verified against the indexed source: {unverified}"
-                )
+            full_answer = self._append_citation_warning(full_answer, citation_check)
 
             yield {
                 "type": "done",
@@ -301,23 +277,24 @@ class LLMService:
             yield {
                 "type": "error",
                 "answer": "Rate limit reached. Please wait a moment and try again.",
-                "error": "rate_limit"
+                "error": "rate_limit",
             }
         except APIError as e:
             yield {
                 "type": "error",
-                "answer": f"API error occurred: {str(e)}",
-                "error": "api_error"
+                "answer": f"API error occurred: {e}",
+                "error": "api_error",
             }
         except Exception as e:
+            logger.error("Streaming LLM error: %s", e)
             yield {
                 "type": "error",
-                "answer": f"Error: {str(e)}",
-                "error": "unknown"
+                "answer": f"Error: {e}",
+                "error": "unknown",
             }
 
     async def count_tokens(self, text: str) -> int:
-        """Count tokens in text using tiktoken"""
+        """Count tokens in text using tiktoken."""
         try:
             import tiktoken
             enc = tiktoken.encoding_for_model("text-embedding-3-small")
@@ -328,26 +305,20 @@ class LLMService:
     async def estimate_response_tokens(
         self,
         query: str,
-        retrieved_chunks: List[Dict[str, Any]]
+        retrieved_chunks: List[Dict[str, Any]],
     ) -> Dict[str, int]:
-        """Estimate token usage before making API call"""
-
+        """Estimate token usage before making an API call."""
         context = self._format_context(retrieved_chunks)
-
-        system_prompt = """You are an expert code analyst..."""
-        system_tokens = await self.count_tokens(system_prompt)
+        system_tokens = await self.count_tokens(self._SYSTEM_PROMPT)
         context_tokens = await self.count_tokens(context)
         query_tokens = await self.count_tokens(query)
-
-        total_input_tokens = system_tokens + context_tokens + query_tokens
-        estimated_response_tokens = self.max_tokens
-
+        total_input = system_tokens + context_tokens + query_tokens
         return {
             "system_tokens": system_tokens,
             "context_tokens": context_tokens,
             "query_tokens": query_tokens,
-            "total_input_tokens": total_input_tokens,
-            "max_response_tokens": estimated_response_tokens,
-            "total_tokens": total_input_tokens + estimated_response_tokens,
-            "within_limit": total_input_tokens < (8000 - estimated_response_tokens)
+            "total_input_tokens": total_input,
+            "max_response_tokens": self.max_tokens,
+            "total_tokens": total_input + self.max_tokens,
+            "within_limit": total_input < (128_000 - self.max_tokens),
         }

--- a/backend/services/providers/__init__.py
+++ b/backend/services/providers/__init__.py
@@ -1,0 +1,17 @@
+"""Provider abstraction layer for LLM and embedding services.
+
+Switching providers requires only environment-variable changes:
+  LLM_PROVIDER=openai|anthropic
+  EMBEDDING_PROVIDER=openai
+  LLM_MODEL=gpt-4o-mini|claude-sonnet-4-6
+  EMBEDDING_MODEL=text-embedding-3-small
+"""
+from backend.services.providers.base import LLMProvider, EmbeddingProvider
+from backend.services.providers.factory import get_llm_provider, get_embedding_provider
+
+__all__ = [
+    "LLMProvider",
+    "EmbeddingProvider",
+    "get_llm_provider",
+    "get_embedding_provider",
+]

--- a/backend/services/providers/anthropic_provider.py
+++ b/backend/services/providers/anthropic_provider.py
@@ -1,0 +1,73 @@
+"""Anthropic Claude LLM provider.
+
+Requires:  ANTHROPIC_API_KEY env var
+           pip install anthropic>=0.27.0
+
+The Anthropic messages API differs from OpenAI in two structural ways:
+  1. The system prompt is a top-level `system` parameter, not a message.
+  2. Response text lives at `response.content[0].text`.
+
+Streaming uses the async context-manager style:
+  async with client.messages.stream(...) as s:
+      async for text in s.text_stream: ...
+
+Note: Anthropic has no embedding API. Use OpenAI or Voyage for embeddings
+when LLM_PROVIDER=anthropic.
+"""
+import logging
+from typing import AsyncIterator, List
+
+from backend.services.providers.base import LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class AnthropicLLMProvider(LLMProvider):
+    """Anthropic Claude provider (claude-sonnet-4-6, claude-haiku-4-5, …)."""
+
+    def __init__(self, api_key: str, model: str):
+        try:
+            import anthropic
+        except ImportError as exc:
+            raise ImportError(
+                "anthropic package is required for LLM_PROVIDER=anthropic. "
+                "Install it with: pip install anthropic>=0.27.0"
+            ) from exc
+
+        self._client = anthropic.AsyncAnthropic(api_key=api_key)
+        self._model = model
+
+    async def complete(
+        self,
+        system: str,
+        messages: List[dict],
+        max_tokens: int = 2000,
+        temperature: float = 0.2,
+    ) -> str:
+        import anthropic
+
+        response = await self._client.messages.create(
+            model=self._model,
+            system=system,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        return response.content[0].text
+
+    async def stream(
+        self,
+        system: str,
+        messages: List[dict],
+        max_tokens: int = 2000,
+        temperature: float = 0.2,
+    ) -> AsyncIterator[str]:
+        async with self._client.messages.stream(
+            model=self._model,
+            system=system,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        ) as stream:
+            async for text in stream.text_stream:
+                yield text

--- a/backend/services/providers/base.py
+++ b/backend/services/providers/base.py
@@ -1,0 +1,58 @@
+"""Abstract base classes for LLM and embedding providers.
+
+All provider implementations must satisfy these interfaces. The canonical
+message format is provider-neutral:
+
+  system: str          — system / instruction prompt
+  messages: list[dict] — alternating {"role": "user"|"assistant", "content": "..."}
+
+Concrete providers translate to their SDK's native format internally.
+"""
+from abc import ABC, abstractmethod
+from typing import AsyncIterator, List
+
+
+class LLMProvider(ABC):
+    """Abstract LLM completion provider."""
+
+    @abstractmethod
+    async def complete(
+        self,
+        system: str,
+        messages: List[dict],
+        max_tokens: int = 2000,
+        temperature: float = 0.2,
+    ) -> str:
+        """Return a complete response string for the given conversation."""
+        ...
+
+    @abstractmethod
+    async def stream(
+        self,
+        system: str,
+        messages: List[dict],
+        max_tokens: int = 2000,
+        temperature: float = 0.2,
+    ) -> AsyncIterator[str]:
+        """Yield response text tokens incrementally."""
+        ...
+
+
+class EmbeddingProvider(ABC):
+    """Abstract embedding provider."""
+
+    @property
+    @abstractmethod
+    def dimensions(self) -> int:
+        """Dimensionality of the embedding vectors produced."""
+        ...
+
+    @abstractmethod
+    async def embed_batch(self, texts: List[str]) -> List[List[float]]:
+        """Return one embedding vector per input text, in the same order."""
+        ...
+
+    async def embed_one(self, text: str) -> List[float]:
+        """Convenience wrapper — embed a single text."""
+        results = await self.embed_batch([text])
+        return results[0]

--- a/backend/services/providers/factory.py
+++ b/backend/services/providers/factory.py
@@ -1,0 +1,62 @@
+"""Factory functions for constructing configured provider instances.
+
+Environment variables:
+  LLM_PROVIDER        openai (default) | anthropic
+  LLM_MODEL           gpt-4o-mini (default) | claude-sonnet-4-6 | …
+  EMBEDDING_PROVIDER  openai (default; only supported option currently)
+  EMBEDDING_MODEL     text-embedding-3-small (default)
+  OPENAI_API_KEY      required when LLM_PROVIDER=openai or EMBEDDING_PROVIDER=openai
+  ANTHROPIC_API_KEY   required when LLM_PROVIDER=anthropic
+"""
+import os
+
+from backend.services.providers.base import LLMProvider, EmbeddingProvider
+
+
+def get_llm_provider() -> LLMProvider:
+    """Return a configured LLMProvider based on LLM_PROVIDER env var."""
+    provider = os.getenv("LLM_PROVIDER", "openai").lower()
+    model = os.getenv("LLM_MODEL", "gpt-4o-mini")
+
+    if provider == "anthropic":
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "ANTHROPIC_API_KEY must be set when LLM_PROVIDER=anthropic"
+            )
+        from backend.services.providers.anthropic_provider import AnthropicLLMProvider
+        return AnthropicLLMProvider(api_key=api_key, model=model)
+
+    if provider == "openai":
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "OPENAI_API_KEY must be set when LLM_PROVIDER=openai"
+            )
+        from backend.services.providers.openai_provider import OpenAILLMProvider
+        return OpenAILLMProvider(api_key=api_key, model=model)
+
+    raise ValueError(
+        f"Unknown LLM_PROVIDER={provider!r}. "
+        "Supported values: openai, anthropic"
+    )
+
+
+def get_embedding_provider() -> EmbeddingProvider:
+    """Return a configured EmbeddingProvider based on EMBEDDING_PROVIDER env var."""
+    provider = os.getenv("EMBEDDING_PROVIDER", "openai").lower()
+    model = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
+
+    if provider == "openai":
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "OPENAI_API_KEY must be set when EMBEDDING_PROVIDER=openai"
+            )
+        from backend.services.providers.openai_provider import OpenAIEmbeddingProvider
+        return OpenAIEmbeddingProvider(api_key=api_key, model=model)
+
+    raise ValueError(
+        f"Unknown EMBEDDING_PROVIDER={provider!r}. "
+        "Supported values: openai"
+    )

--- a/backend/services/providers/openai_provider.py
+++ b/backend/services/providers/openai_provider.py
@@ -1,0 +1,110 @@
+"""OpenAI concrete providers for LLM completions and embeddings."""
+import asyncio
+import logging
+from typing import AsyncIterator, List
+
+from openai import AsyncOpenAI, RateLimitError, APIStatusError
+
+from backend.services.providers.base import LLMProvider, EmbeddingProvider
+
+logger = logging.getLogger(__name__)
+
+_EMBED_BATCH_SIZE = 2000
+_MAX_RETRIES = 3
+
+
+class OpenAILLMProvider(LLMProvider):
+    """OpenAI chat-completions provider (gpt-4o-mini, gpt-4o, gpt-4, …)."""
+
+    def __init__(self, api_key: str, model: str):
+        self._client = AsyncOpenAI(api_key=api_key)
+        self._model = model
+
+    def _build_messages(self, system: str, messages: List[dict]) -> List[dict]:
+        return [{"role": "system", "content": system}, *messages]
+
+    async def complete(
+        self,
+        system: str,
+        messages: List[dict],
+        max_tokens: int = 2000,
+        temperature: float = 0.2,
+    ) -> str:
+        response = await self._client.chat.completions.create(
+            model=self._model,
+            messages=self._build_messages(system, messages),
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        return response.choices[0].message.content
+
+    async def stream(
+        self,
+        system: str,
+        messages: List[dict],
+        max_tokens: int = 2000,
+        temperature: float = 0.2,
+    ) -> AsyncIterator[str]:
+        stream = await self._client.chat.completions.create(
+            model=self._model,
+            messages=self._build_messages(system, messages),
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=True,
+        )
+        async for chunk in stream:
+            if chunk.choices[0].delta.content:
+                yield chunk.choices[0].delta.content
+
+
+class OpenAIEmbeddingProvider(EmbeddingProvider):
+    """OpenAI embeddings provider (text-embedding-3-small, text-embedding-3-large, …)."""
+
+    def __init__(self, api_key: str, model: str, dims: int = 1536):
+        self._client = AsyncOpenAI(api_key=api_key)
+        self._model = model
+        self._dimensions = dims
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions
+
+    async def _batch_with_retry(self, batch: List[str]) -> List[List[float]]:
+        delay = 1.0
+        for attempt in range(1, _MAX_RETRIES + 1):
+            try:
+                response = await self._client.embeddings.create(
+                    model=self._model,
+                    input=batch,
+                    encoding_format="float",
+                )
+                return [item.embedding for item in response.data]
+            except RateLimitError:
+                if attempt == _MAX_RETRIES:
+                    raise
+                logger.warning(
+                    "Embedding rate-limited (attempt %d/%d), retrying in %.1fs",
+                    attempt, _MAX_RETRIES, delay,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+            except APIStatusError as exc:
+                if exc.status_code >= 500 and attempt < _MAX_RETRIES:
+                    logger.warning(
+                        "Embedding API %d error (attempt %d/%d), retrying in %.1fs",
+                        exc.status_code, attempt, _MAX_RETRIES, delay,
+                    )
+                    await asyncio.sleep(delay)
+                    delay *= 2
+                else:
+                    raise
+        return []
+
+    async def embed_batch(self, texts: List[str]) -> List[List[float]]:
+        if not texts:
+            return []
+        result: List[List[float]] = []
+        for i in range(0, len(texts), _EMBED_BATCH_SIZE):
+            batch = texts[i: i + _EMBED_BATCH_SIZE]
+            result.extend(await self._batch_with_retry(batch))
+        return result


### PR DESCRIPTION
Closes #63, #64

## Summary

- New `backend/services/providers/` package: abstract interfaces + OpenAI and Anthropic concrete implementations
- `LLMService` and `EmbeddingService` delegate to pluggable providers — callers unchanged
- `RepositoryProcessor`, `KeywordSearchService`, `RAGPipeline` registered as `app.state` singletons at startup
- Switching LLM provider now requires only `.env` changes

## Provider Abstraction (closes #63)

**New files:**
- `providers/base.py` — `LLMProvider` and `EmbeddingProvider` abstract base classes
- `providers/openai_provider.py` — `OpenAILLMProvider`, `OpenAIEmbeddingProvider`
- `providers/anthropic_provider.py` — `AnthropicLLMProvider` (lazy-imported; startup safe without `anthropic` package)
- `providers/factory.py` — `get_llm_provider()`, `get_embedding_provider()` reading env vars

**Interface design:**
- `LLMProvider.complete(system, messages, ...)` / `.stream(...)` — provider-neutral (no OpenAI-specific shapes)
- `EmbeddingProvider.embed_batch(texts)` / `.embed_one(text)` — includes batching and retry in OpenAI impl
- `AnthropicLLMProvider` correctly uses the top-level `system` parameter (separate from `messages`) and `messages.stream()` context manager

**Switching to Claude:**
```bash
LLM_PROVIDER=anthropic
LLM_MODEL=claude-sonnet-4-6
ANTHROPIC_API_KEY=sk-ant-...
```
No code changes required.

## Singleton Services (closes #64)

`main.py` `lifespan` now registers:
```python
app.state.processor = RepositoryProcessor()
app.state.keyword_service = keyword_search   # already created for index setup
app.state.rag_pipeline = RAGPipeline()
```

Route handlers retrieve via `request.app.state.*` — no per-request service allocation.

## Other changes
- `backend/requirements.txt`: `anthropic>=0.27.0` added
- `backend/.env.example`: fully documented with all provider variables, inline comments, model options

## Test Plan

- [x] 41/41 tests pass with default `LLM_PROVIDER=openai` configuration
- [x] No import errors when `anthropic` package is absent (lazy-loaded)
- [x] `ANTHROPIC_API_KEY` missing with `LLM_PROVIDER=anthropic` raises `ValueError` at startup
- [x] All API response shapes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)