### PR TITLE
feat: async ingestion, BM25 reranking, private repo import, chunk summaries

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -53,3 +53,10 @@ ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 # Create at: https://github.com/settings/tokens
 # Leave blank for public repositories only.
 GITHUB_TOKEN=
+
+# ── Indexing features ────────────────────────────────────────────────────────
+# Generate LLM summaries for each code chunk before embedding.
+# Summaries are prepended to chunk content, improving retrieval for
+# conceptual queries (e.g. "where is authentication handled?").
+# Increases indexing cost and time — disabled by default.
+ENABLE_CHUNK_SUMMARIES=false

--- a/backend/api/repositories.py
+++ b/backend/api/repositories.py
@@ -6,7 +6,7 @@ Endpoints for repository management.
 Phase 13: Added JWT authentication and authorization
 """
 
-from fastapi import APIRouter, HTTPException, status, Depends, Request, UploadFile, File, Form
+from fastapi import APIRouter, BackgroundTasks, HTTPException, status, Depends, Request, UploadFile, File, Form
 from fastapi.responses import JSONResponse
 from typing import List, Optional
 from datetime import datetime
@@ -31,6 +31,47 @@ from backend.services.keyword_search import KeywordSearchService
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/repositories", tags=["repositories"])
+
+
+async def _run_ingestion(
+    repo_id: str,
+    extract_base: str,
+    temp_dir: str,
+    processor: RepositoryProcessor,
+    incremental: bool = False,
+) -> None:
+    """Background task: run ingestion and update repository status.
+
+    Owns the temp_dir lifecycle — always cleans up on exit regardless of outcome.
+    """
+    db = Database.get_db()
+    try:
+        await db.repositories.update_one(
+            {"_id": ObjectId(repo_id)},
+            {"$set": {"status": "indexing"}},
+        )
+        if incremental:
+            result = await processor.process_repository_incremental(repo_id, extract_base)
+        else:
+            result = await processor.process_repository(repo_id, extract_base)
+
+        final_status = "indexed" if result.get("status") == "success" else "failed"
+        await db.repositories.update_one(
+            {"_id": ObjectId(repo_id)},
+            {"$set": {
+                "status": final_status,
+                "processing": result,
+                "updated_at": datetime.now(),
+            }},
+        )
+    except Exception as exc:
+        logger.error("Ingestion background task failed for %s: %s", repo_id, exc)
+        await db.repositories.update_one(
+            {"_id": ObjectId(repo_id)},
+            {"$set": {"status": "failed", "error": str(exc), "updated_at": datetime.now()}},
+        )
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 def serialize_doc(doc: dict) -> dict:
@@ -143,90 +184,92 @@ async def create_repository(
     return doc
 
 
-@router.post("/upload", status_code=status.HTTP_201_CREATED)
+@router.post("/upload", status_code=status.HTTP_202_ACCEPTED)
 @limiter.limit("10/minute")
 async def upload_repository(
     request: Request,
+    background_tasks: BackgroundTasks,
     file: UploadFile = File(...),
     name: Optional[str] = Form(None),
     description: Optional[str] = Form(None),
     current_user: dict = Depends(get_current_user)
 ):
-    """
-    POST /repositories/upload - Upload repository as ZIP file
-    
-    Accepts a ZIP file containing code files.
-    Processes and indexes the uploaded code.
-    
-    Args:
-        file: ZIP file containing code
-        name: Repository name (optional, extracted from ZIP if not provided)
-        description: Repository description
-    
-    Returns:
-        Created repository with processing stats
-    
-    Requires authentication.
-    Rate limit: 10 requests per minute.
+    """POST /repositories/upload — Upload repository as ZIP and index asynchronously.
+
+    Extracts the ZIP, inserts the repository record with status='pending', and
+    schedules indexing as a background task. Returns immediately (HTTP 202).
+
+    Poll GET /repositories/{id}/status to track progress.
     """
     if not file.filename.endswith('.zip'):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Only ZIP files are accepted"
         )
-    
+
     db = Database.get_db()
     user_id = current_user.get("user_id")
-    
-    with tempfile.TemporaryDirectory() as temp_dir:
+
+    # mkdtemp instead of TemporaryDirectory — background task owns cleanup.
+    temp_dir = tempfile.mkdtemp()
+    try:
         zip_path = os.path.join(temp_dir, file.filename)
-        
         with open(zip_path, 'wb') as f:
             shutil.copyfileobj(file.file, f)
-        
+
         with zipfile.ZipFile(zip_path, 'r') as zip_ref:
             zip_ref.extractall(temp_dir)
-        
-        root_content = os.listdir(temp_dir)
+
+        root_content = [e for e in os.listdir(temp_dir) if e != os.path.basename(zip_path)]
         subdirectory = None
         extract_base = temp_dir
-        
         if len(root_content) == 1 and os.path.isdir(os.path.join(temp_dir, root_content[0])):
             subdirectory = root_content[0]
             extract_base = os.path.join(temp_dir, subdirectory)
-        
+
         repo_name = name or subdirectory or file.filename.replace('.zip', '')
-        
+
         doc = {
             "name": repo_name,
             "description": description or "",
             "user_id": user_id,
-            "file_path": extract_base,
+            "status": "pending",
             "created_at": datetime.now(),
-            "updated_at": None
+            "updated_at": None,
         }
-        
+
         result = await db.repositories.insert_one(doc)
         repo_id = str(result.inserted_id)
-        
-        processor: RepositoryProcessor = request.app.state.processor
-        processing_result = await processor.process_repository(repo_id, extract_base)
+
+        background_tasks.add_task(
+            _run_ingestion,
+            repo_id,
+            extract_base,
+            temp_dir,
+            request.app.state.processor,
+            False,
+        )
 
         return {
             "id": repo_id,
-            "name": doc["name"],
+            "name": repo_name,
             "description": doc["description"],
+            "status": "pending",
             "created_at": doc["created_at"],
-            "updated_at": doc["updated_at"],
-            "processing": processing_result
+            "updated_at": None,
         }
 
+    except Exception:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise
 
-@router.post("/{repo_id}/reindex", status_code=status.HTTP_200_OK)
+
+@router.post("/{repo_id}/reindex", status_code=status.HTTP_202_ACCEPTED)
 @limiter.limit("5/minute")
 async def reindex_repository(
     request: Request,
     repo_id: str,
+    background_tasks: BackgroundTasks,
     file: UploadFile = File(...),
     current_user: dict = Depends(get_current_user)
 ):
@@ -234,7 +277,10 @@ async def reindex_repository(
 
     Computes MD5 content hashes and skips files whose hash matches the
     stored value. Only changed and new files are re-embedded; chunks for
-    removed files are deleted. Rate limit: 5 requests per minute.
+    removed files are deleted. Returns 202 immediately — poll
+    GET /repositories/{id}/status to track progress.
+
+    Rate limit: 5 requests per minute.
     """
     if not file.filename.endswith(".zip"):
         raise HTTPException(
@@ -256,7 +302,8 @@ async def reindex_repository(
     if repo.get("user_id") and repo["user_id"] != user_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You do not have access to this repository")
 
-    with tempfile.TemporaryDirectory() as temp_dir:
+    temp_dir = tempfile.mkdtemp()
+    try:
         zip_path = os.path.join(temp_dir, file.filename)
         with open(zip_path, "wb") as f:
             shutil.copyfileobj(file.file, f)
@@ -264,20 +311,30 @@ async def reindex_repository(
         with zipfile.ZipFile(zip_path, "r") as zip_ref:
             zip_ref.extractall(temp_dir)
 
-        root_content = os.listdir(temp_dir)
+        root_content = [e for e in os.listdir(temp_dir) if e != os.path.basename(zip_path)]
         extract_base = temp_dir
         if len(root_content) == 1 and os.path.isdir(os.path.join(temp_dir, root_content[0])):
             extract_base = os.path.join(temp_dir, root_content[0])
 
-        processor: RepositoryProcessor = request.app.state.processor
-        result = await processor.process_repository_incremental(repo_id, extract_base)
+        await db.repositories.update_one(
+            {"_id": ObjectId(repo_id)},
+            {"$set": {"status": "pending", "updated_at": datetime.now()}},
+        )
 
-    await db.repositories.update_one(
-        {"_id": ObjectId(repo_id)},
-        {"$set": {"updated_at": datetime.now()}}
-    )
+        background_tasks.add_task(
+            _run_ingestion,
+            repo_id,
+            extract_base,
+            temp_dir,
+            request.app.state.processor,
+            True,
+        )
 
-    return {"repository_id": repo_id, **result}
+        return {"repository_id": repo_id, "status": "pending"}
+
+    except Exception:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise
 
 
 @router.put("/{repo_id}", response_model=RepositoryResponse)
@@ -527,25 +584,70 @@ async def get_repository_stats(
     }
 
 
+@router.get("/{repo_id}/status")
+@limiter.limit("60/minute")
+async def get_repository_status(
+    request: Request,
+    repo_id: str,
+    current_user: dict = Depends(get_current_user)
+):
+    """GET /repositories/{id}/status — Poll async ingestion progress.
+
+    Returns:
+        id, name, status — one of: pending | indexing | indexed | failed
+        processing — result dict from the processor (present once indexed)
+        error — error message (present when status is 'failed')
+
+    Rate limit: 60 requests per minute.
+    """
+    db = Database.get_db()
+    user_id = current_user.get("user_id")
+
+    try:
+        repo = await db.repositories.find_one({"_id": ObjectId(repo_id)})
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid repository ID format")
+
+    if not repo:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Repository '{repo_id}' not found")
+
+    if repo.get("user_id") and repo["user_id"] != user_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You do not have access to this repository")
+
+    response: dict = {
+        "id": repo_id,
+        "name": repo.get("name", ""),
+        "status": repo.get("status", "unknown"),
+    }
+    if "processing" in repo:
+        response["processing"] = repo["processing"]
+    if "error" in repo:
+        response["error"] = repo["error"]
+
+    return response
+
+
 _GITHUB_URL_RE = re.compile(
     r'^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\.git)?/?$'
 )
 
 
-@router.post("/import", status_code=status.HTTP_201_CREATED)
+@router.post("/import", status_code=status.HTTP_202_ACCEPTED)
 @limiter.limit("5/minute")
 async def import_repository(
     request: Request,
     payload: RepositoryImport,
+    background_tasks: BackgroundTasks,
     current_user: dict = Depends(get_current_user)
 ):
-    """Clone a public GitHub repository and index it.
+    """Clone a GitHub repository and index it asynchronously.
 
-    Accepts a GitHub HTTPS URL, clones with depth=1 into a temporary
-    directory, runs the standard RepositoryProcessor pipeline, then
-    cleans up the clone. Private repositories are not supported without
-    a configured GitHub token.
+    Validates the URL and performs the git clone synchronously (so auth/
+    network errors surface immediately), then schedules indexing as a
+    background task and returns 202. Poll GET /repositories/{id}/status
+    to track progress.
 
+    Private repositories require GITHUB_TOKEN to be configured.
     Rate limit: 5 requests per minute (clone is network-bound).
     """
     url = payload.url.strip().rstrip("/")
@@ -555,33 +657,53 @@ async def import_repository(
     if not _GITHUB_URL_RE.match(url + "/"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="URL must be a public GitHub repository (https://github.com/owner/repo)"
+            detail="URL must be a GitHub repository (https://github.com/owner/repo)"
         )
+
+    # Inject GITHUB_TOKEN for private repository access.
+    # The token is embedded in the URL so it is never logged by git output.
+    github_token = os.getenv("GITHUB_TOKEN", "").strip()
+    clone_url = url
+    if github_token:
+        # https://github.com/owner/repo → https://<token>@github.com/owner/repo
+        clone_url = url.replace("https://", f"https://{github_token}@", 1)
 
     repo_slug = url.split("/")[-1]
     repo_name = payload.name or repo_slug
     db = Database.get_db()
     user_id = current_user.get("user_id")
 
-    with tempfile.TemporaryDirectory() as temp_dir:
+    # mkdtemp — background task owns cleanup via _run_ingestion finally block.
+    temp_dir = tempfile.mkdtemp()
+    try:
         clone_path = os.path.join(temp_dir, repo_slug)
 
+        clone_cmd = ["git", "clone", "--depth", "1"]
+        if payload.branch:
+            clone_cmd += ["--branch", payload.branch]
+        clone_cmd += [clone_url, clone_path]
+
         proc = await asyncio.create_subprocess_exec(
-            "git", "clone", "--depth", "1", url, clone_path,
+            *clone_cmd,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE
+            stderr=asyncio.subprocess.PIPE,
         )
         try:
             _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
         except asyncio.TimeoutError:
             proc.kill()
+            shutil.rmtree(temp_dir, ignore_errors=True)
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail="Clone timed out after 120 seconds"
             )
 
         if proc.returncode != 0:
+            # Scrub the token from stderr before returning it to the client.
             error_msg = stderr.decode(errors="replace").strip()
+            if github_token:
+                error_msg = error_msg.replace(github_token, "***")
+            shutil.rmtree(temp_dir, ignore_errors=True)
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=f"Clone failed: {error_msg}"
@@ -592,30 +714,35 @@ async def import_repository(
             "description": payload.description or f"Imported from {url}",
             "user_id": user_id,
             "source_url": url,
+            "status": "pending",
             "created_at": datetime.now(),
-            "updated_at": None
+            "updated_at": None,
         }
 
         result = await db.repositories.insert_one(doc)
         repo_id = str(result.inserted_id)
 
-        try:
-            processor: RepositoryProcessor = request.app.state.processor
-            processing_result = await processor.process_repository(repo_id, clone_path)
-        except Exception as exc:
-            await db.repositories.delete_one({"_id": result.inserted_id})
-            logger.error("Processing failed for import %s: %s", url, exc)
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Indexing failed: {exc}"
-            )
+        background_tasks.add_task(
+            _run_ingestion,
+            repo_id,
+            clone_path,
+            temp_dir,
+            request.app.state.processor,
+            False,
+        )
 
-    return {
-        "id": repo_id,
-        "name": repo_name,
-        "description": doc["description"],
-        "source_url": url,
-        "created_at": doc["created_at"],
-        "updated_at": None,
-        "processing": processing_result
-    }
+        return {
+            "id": repo_id,
+            "name": repo_name,
+            "description": doc["description"],
+            "source_url": url,
+            "status": "pending",
+            "created_at": doc["created_at"],
+            "updated_at": None,
+        }
+
+    except HTTPException:
+        raise
+    except Exception:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise

--- a/backend/models/repository.py
+++ b/backend/models/repository.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, field_serializer
-from typing import Optional
+from typing import Optional, Literal
 from datetime import datetime
 from bson import ObjectId
 
@@ -18,9 +18,13 @@ class RepositoryCreate(RepositoryBase):
 
 class RepositoryImport(BaseModel):
     """Model for importing a repository from a GitHub URL"""
-    url: str = Field(..., description="Public GitHub repository URL")
+    url: str = Field(..., description="GitHub repository URL (public or private)")
     name: Optional[str] = Field(None, min_length=1, max_length=100)
     description: Optional[str] = None
+    branch: Optional[str] = Field(
+        None,
+        description="Branch to clone (defaults to repository HEAD)"
+    )
 
 
 class RepositoryUpdate(BaseModel):
@@ -35,7 +39,8 @@ class RepositoryResponse(RepositoryBase):
     id: str
     created_at: datetime
     updated_at: Optional[datetime] = None
-    
+    status: Optional[str] = None
+
     class Config:
         from_attributes = True
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,7 @@ slowapi==0.1.9
 numpy==2.2.2
 cohere>=5.0.0
 anthropic>=0.27.0
+rank-bm25>=0.2.2
 tree-sitter>=0.21.0
 tree-sitter-python
 tree-sitter-javascript

--- a/backend/services/hybrid_search.py
+++ b/backend/services/hybrid_search.py
@@ -53,7 +53,7 @@ class HybridSearchService:
             reranked = await self._cohere_rerank(combined, query, limit)
         except Exception as e:
             logger.warning("Cohere rerank unavailable (%s), using heuristic rerank", e)
-            reranked = self._rerank(combined, query)
+            reranked = self._bm25_rerank(combined, query)
 
         return reranked[:limit]
     
@@ -176,42 +176,33 @@ class HybridSearchService:
                 return rank
         return None
     
-    def _rerank(
-        self, 
-        results: List[Dict], 
-        query: str
-    ) -> List[Dict]:
-        """Apply reranking with exact match bonus
-        
-        Args:
-            results: Combined results from RRF
-            query: Original search query
-            
-        Returns:
-            Reranked results
+    def _bm25_rerank(self, results: List[Dict], query: str) -> List[Dict]:
+        """Re-rank RRF results using in-process BM25 (Okapi BM25).
+
+        BM25 correctly normalises for document length and term frequency,
+        replacing the previous ad-hoc term-count heuristic. Used when
+        COHERE_API_KEY is not configured.
         """
-        query_terms = query.lower().split()
-        
+        if not results:
+            return results
+
+        from rank_bm25 import BM25Okapi
+
+        # Build corpus from content; prepend symbol name to weight it higher.
+        corpus = []
         for doc in results:
-            bonus = 0.0
-            content = doc.get("content", "").lower()
-            metadata = doc.get("metadata", {})
-            name = metadata.get("name", "").lower()
-            
-            for term in query_terms:
-                if len(term) < 3:
-                    continue
-                
-                if term in name:
-                    bonus += 0.2
-                
-                if term in content:
-                    term_count = content.count(term)
-                    if term_count > 0:
-                        bonus += min(0.1 * min(term_count, 5), 0.3)
-            
-            doc["hybrid_score"] = doc.get("hybrid_score", 0) + bonus
-        
+            meta = doc.get("metadata", {})
+            name_tokens = meta.get("name", "").lower().split("_")
+            content_tokens = doc.get("content", "").lower().split()
+            # name tokens repeated to give them implicit higher weight
+            corpus.append(name_tokens * 3 + content_tokens)
+
+        query_tokens = query.lower().split()
+        scores = BM25Okapi(corpus).get_scores(query_tokens)
+
+        for i, doc in enumerate(results):
+            doc["hybrid_score"] = float(scores[i])
+
         return sorted(results, key=lambda x: x.get("hybrid_score", 0), reverse=True)
     
     async def search_with_filters(

--- a/backend/services/processor.py
+++ b/backend/services/processor.py
@@ -4,16 +4,25 @@ from backend.services.chunker import CodeChunker
 from backend.services.vector_store import VectorStore
 from typing import Dict, Any, Optional
 import hashlib
+import logging
 import os
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+_SUMMARIES_ENABLED = os.getenv("ENABLE_CHUNK_SUMMARIES", "false").lower() == "true"
 
 
 class RepositoryProcessor:
     """Orchestrates repository processing: scan -> chunk -> embed -> store"""
-    
+
     def __init__(self):
         self.vector_store = VectorStore()
         self.chunker = CodeChunker(max_tokens=1000, overlap=100)
+        self._summary_service = None
+        if _SUMMARIES_ENABLED:
+            from backend.services.summary import SummaryService
+            self._summary_service = SummaryService()
     
     async def process_repository(self, repository_id: str, local_path: str) -> Dict[str, Any]:
         """Process a local repository: scan, chunk, embed, and store
@@ -58,15 +67,30 @@ class RepositoryProcessor:
                 "chunks_created": 0
             }
         
+        await self._enrich_with_summaries(all_chunks)
         chunks_added = await self.vector_store.add_chunks(all_chunks, repository_id)
-        
+
         return {
             "status": "success",
             "message": f"Processed {len(files)} files, created {chunks_added} chunks",
             "files_processed": len(files),
             "chunks_created": chunks_added
         }
-    
+
+    async def _enrich_with_summaries(self, chunks: list) -> None:
+        """Attach LLM-generated summaries to chunks when ENABLE_CHUNK_SUMMARIES=true.
+
+        Summaries are stored in chunk["summary"] and later written to metadata.
+        No-op when the feature is disabled or summary service is not initialised.
+        """
+        if not self._summary_service or not chunks:
+            return
+        logger.info("Generating summaries for %d chunks...", len(chunks))
+        summaries = await self._summary_service.summarize_chunks(chunks)
+        for chunk, summary in zip(chunks, summaries):
+            if summary:
+                chunk["summary"] = summary
+
     async def reprocess_repository(self, repository_id: str, local_path: str) -> Dict[str, Any]:
         """Reprocess repository (clears existing chunks first)
         
@@ -154,6 +178,7 @@ class RepositoryProcessor:
 
         chunks_added = 0
         if all_chunks:
+            await self._enrich_with_summaries(all_chunks)
             await self.vector_store.ensure_indexes()
             chunks_added = await self.vector_store.add_chunks(all_chunks, repository_id)
 

--- a/backend/services/summary.py
+++ b/backend/services/summary.py
@@ -1,0 +1,63 @@
+"""Chunk summary generation service.
+
+Generates a one-sentence natural-language summary for each code chunk using
+the configured LLM provider. Summaries are prepended to the chunk content
+before embedding, improving semantic retrieval for conceptual queries.
+
+Controlled by the ENABLE_CHUNK_SUMMARIES environment variable (default: false).
+"""
+import asyncio
+import logging
+from typing import Dict, List, Optional
+
+from backend.services.providers.factory import get_llm_provider
+from backend.services.providers.base import LLMProvider
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = (
+    "You are a code search indexing assistant. "
+    "Summarize the provided code in exactly one sentence. "
+    "State what the code does — its purpose — not implementation details. "
+    "Output only the sentence, no preamble."
+)
+
+
+class SummaryService:
+    """Generates one-sentence summaries for code chunks using the LLM provider."""
+
+    def __init__(self, provider: Optional[LLMProvider] = None, concurrency: int = 10):
+        self._provider = provider or get_llm_provider()
+        self._semaphore = asyncio.Semaphore(concurrency)
+
+    async def summarize_chunk(self, content: str, chunk_type: str = "", name: str = "") -> str:
+        """Return a one-sentence summary for a single chunk, or '' on failure."""
+        if not content or not content.strip():
+            return ""
+
+        label = f"{chunk_type}: {name}" if name else chunk_type
+        user_message = f"Code chunk ({label}):\n\n{content}" if label else content
+
+        async with self._semaphore:
+            try:
+                return await self._provider.complete(
+                    _SYSTEM_PROMPT,
+                    [{"role": "user", "content": user_message}],
+                    max_tokens=100,
+                    temperature=0.0,
+                )
+            except Exception as exc:
+                logger.warning("Summary generation failed for chunk '%s': %s", name, exc)
+                return ""
+
+    async def summarize_chunks(self, chunks: List[Dict]) -> List[str]:
+        """Return one summary per chunk, in the same order. Failures return ''."""
+        tasks = [
+            self.summarize_chunk(
+                chunk.get("content", ""),
+                chunk.get("chunk_type", ""),
+                chunk.get("name", ""),
+            )
+            for chunk in chunks
+        ]
+        return await asyncio.gather(*tasks)

--- a/backend/services/vector_store.py
+++ b/backend/services/vector_store.py
@@ -45,24 +45,31 @@ class VectorStore:
 
         db = Database.get_db()
 
-        texts = [chunk["content"] for chunk in chunks]
+        texts = []
+        for chunk in chunks:
+            summary = chunk.get("summary", "")
+            texts.append(f"{summary}\n\n{chunk['content']}" if summary else chunk["content"])
+
         embeddings = await self.embedding_service.generate_embeddings(texts)
 
         documents = []
         for chunk, embedding in zip(chunks, embeddings):
+            metadata: Dict[str, Any] = {
+                "file_path": chunk.get("file_path", ""),
+                "chunk_type": chunk.get("chunk_type", "unknown"),
+                "name": chunk.get("name", ""),
+                "start_line": chunk.get("start_line", 0),
+                "end_line": chunk.get("end_line", 0),
+                "token_count": chunk.get("token_count", 0),
+                "file_hash": chunk.get("file_hash", ""),
+            }
+            if chunk.get("summary"):
+                metadata["summary"] = chunk["summary"]
             documents.append({
                 "repository_id": repository_id,
                 "content": chunk["content"],
                 "embedding": embedding,
-                "metadata": {
-                    "file_path": chunk.get("file_path", ""),
-                    "chunk_type": chunk.get("chunk_type", "unknown"),
-                    "name": chunk.get("name", ""),
-                    "start_line": chunk.get("start_line", 0),
-                    "end_line": chunk.get("end_line", 0),
-                    "token_count": chunk.get("token_count", 0),
-                    "file_hash": chunk.get("file_hash", "")
-                }
+                "metadata": metadata,
             })
 
         if documents:


### PR DESCRIPTION
## Summary

Closes #67, #68, #69, #70.

- **Async ingestion (#67)**: `upload`, `reindex`, and `import` endpoints now return `202 Accepted` immediately. A `_run_ingestion` background task owns the temp directory lifecycle and drives the repository through a `pending → indexing → indexed | failed` status state machine. New `GET /repositories/{id}/status` endpoint exposes progress for polling.

- **Private repository import (#68)**: `GITHUB_TOKEN` is injected into the clone URL for private repo access. Token is scrubbed from stderr before any error is returned to the client. Optional `branch` field added to `RepositoryImport` for selecting non-default branches.

- **BM25 fallback reranking (#69)**: Replaced the ad-hoc term-count heuristic in the Cohere fallback path with `BM25Okapi` from `rank-bm25`. Symbol name tokens are weighted 3× over body content to surface exact-match results higher.

- **Chunk summaries (#70)**: New `SummaryService` generates a one-sentence LLM summary per chunk using `asyncio.Semaphore(10)` for concurrency control. When `ENABLE_CHUNK_SUMMARIES=true`, summaries are prepended to chunk content before embedding and cached in `metadata.summary`, improving retrieval for conceptual queries. Disabled by default.

## Test plan

- [ ] All 41 existing tests pass (`pytest backend/tests/ -q`)
- [ ] Upload a ZIP via `POST /repositories/upload` — returns `202` with `status: "pending"`
- [ ] Poll `GET /repositories/{id}/status` — watch `pending → indexing → indexed`
- [ ] Import a public GitHub repo via `POST /repositories/import` — returns `202` immediately, clone validates synchronously
- [ ] Delete a repo — chunks are removed from MongoDB (orphan fix from Track 1 still in place)
- [ ] Set `ENABLE_CHUNK_SUMMARIES=true`, re-index a small repo — confirm `metadata.summary` field appears in stored chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)