### PR TITLE
docs: restructure for professional repo presentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,45 +6,11 @@ Thank you for your interest in contributing. This guide covers how to set up a d
 
 ## Development Setup
 
-### Prerequisites
+Follow the [Quick Start in README.md](README.md#quick-start) to clone, install dependencies, configure `backend/.env`, and start both servers.
 
-- Python 3.10+
-- Node.js 18+
-- `git` on PATH
-- MongoDB Atlas account (free M0 tier)
-- OpenAI API key
+Once both are running, Swagger UI is available at `http://localhost:8000/docs` — useful for manual API testing without the frontend.
 
-### Backend
-
-```bash
-# Clone the repository
-git clone https://github.com/shivam-tamboli/AI-CodeBase-Assistant.git
-cd AI-CodeBase-Assistant
-
-# Create virtual environment
-python -m venv venv
-source venv/bin/activate          # Windows: venv\Scripts\activate
-
-# Install all dependencies including dev tools
-pip install -r backend/requirements.txt
-
-# Configure environment
-cp backend/.env.example backend/.env
-# Edit backend/.env — minimum: OPENAI_API_KEY, MONGODB_URI, JWT_SECRET
-
-# Start the dev server with auto-reload
-uvicorn backend.main:app --reload
-```
-
-Swagger UI is available at `http://localhost:8000/docs` — useful for manual API testing without needing the frontend.
-
-### Frontend
-
-```bash
-cd frontend
-npm install
-npm run dev    # http://localhost:5173
-```
+For common startup errors and their fixes, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ python -m pytest backend/tests/ -q
 ├── pytest.ini                        # asyncio_mode=auto, testpaths=backend/tests
 ├── ARCHITECTURE.md                   # Technical deep dive with component diagrams
 ├── CONTRIBUTING.md                   # Development setup and contribution guidelines
+├── TROUBLESHOOTING.md                # Common errors, root causes, and fixes
 └── docs/
     ├── deployment.md                 # MongoDB Atlas, Render, Vercel step-by-step
     ├── search-pipeline.md            # Hybrid search system internals
@@ -401,6 +402,7 @@ python -m pytest backend/tests/ -q
 | [docs/deployment.md](docs/deployment.md) | Step-by-step deployment: Atlas, Render/Railway, Vercel |
 | [docs/search-pipeline.md](docs/search-pipeline.md) | Hybrid search internals: RRF, BM25, Cohere |
 | [docs/provider-architecture.md](docs/provider-architecture.md) | LLM/embedding provider system and how to add new providers |
+| [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Common errors, root causes, and diagnostic steps |
 
 ---
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,6 +1,9 @@
-# Debugging & Setup Guide
+# Troubleshooting
 
-Complete reference for running, troubleshooting, and understanding common failures in the AI Codebase Assistant.
+Complete reference for diagnosing and fixing common failures in the AI Codebase Assistant.
+
+> For setup and startup instructions, see [README.md](README.md#quick-start).  
+> For deployment, see [docs/deployment.md](docs/deployment.md).
 
 ---
 
@@ -14,76 +17,6 @@ Complete reference for running, troubleshooting, and understanding common failur
 | `ANTHROPIC_API_KEY` | Only if `LLM_PROVIDER=anthropic` | https://console.anthropic.com |
 | `COHERE_API_KEY` | No (enables better re-ranking) | https://cohere.com (free tier: 1000 req/month) |
 | `GITHUB_TOKEN` | No (enables private repo import) | https://github.com/settings/tokens → scope: `repo` (read-only) |
-
----
-
-## How to Run the Project
-
-### 1. Clone and set up
-
-```bash
-git clone https://github.com/shivam-tamboli/AI-CodeBase-Assistant.git
-cd AI-CodeBase-Assistant
-```
-
-### 2. Create the backend virtual environment
-
-```bash
-python3.12 -m venv venv          # must be Python 3.12
-source venv/bin/activate
-python3 -m pip install -r backend/requirements.txt
-```
-
-> **Important**: Use `python3 -m pip install` not just `pip install`. If the venv was created from a different directory and then the project was moved/renamed, the `pip` shebang breaks. Using `python3 -m pip` bypasses the shebang entirely.
-
-### 3. Create `backend/.env`
-
-Copy the template and fill in values:
-
-```bash
-cp backend/.env.example backend/.env
-```
-
-Minimum required values:
-
-```
-OPENAI_API_KEY=sk-proj-...
-MONGODB_URI=mongodb+srv://user:pass@cluster0.xxxxx.mongodb.net/ragdb?retryWrites=true&w=majority
-JWT_SECRET=<64-char hex string>
-ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174
-```
-
-### 4. Start the backend
-
-```bash
-# From the project root with venv active
-source venv/bin/activate
-uvicorn backend.main:app --reload
-```
-
-Expected output:
-```
-Connected to MongoDB
-Users collection indexes initialized
-Indexes and services initialized
-INFO: Uvicorn running on http://0.0.0.0:8000
-```
-
-### 5. Start the frontend
-
-```bash
-cd frontend
-npm install        # first time only
-npm run dev
-```
-
-Expected output:
-```
-VITE ready in Xms
-Local: http://localhost:5173/
-```
-
-The frontend is pinned to port **5173** via `vite.config.js` (`strictPort: true`). If 5173 is already in use, Vite will fail with an error rather than silently using 5174 — which would cause CORS failures.
 
 ---
 
@@ -110,7 +43,7 @@ source venv/bin/activate && uvicorn backend.main:app --reload
 cd frontend && npm run dev
 ```
 
-**Prevention**: `vite.config.js` now has `strictPort: true` — if 5173 is taken, `npm run dev` fails immediately with a clear error instead of silently using 5174.
+**Prevention**: `vite.config.js` has `strictPort: true` — if 5173 is taken, `npm run dev` fails immediately with a clear error instead of silently using 5174.
 
 ---
 
@@ -282,23 +215,3 @@ curl -X OPTIONS http://localhost:8000/auth/login \
 | 6 | Same ZIP can't be re-uploaded | Native `<input>` value not cleared after upload | Add `inputRef.current.value = ''` | #77 |
 | 7 | Hint chips did nothing | `<span>` elements with no onClick | Add `onClick={() => setQuestion(hint)}` | #77 |
 | 8 | Chat works on pending repo | No readiness guard on chat input | Disable textarea+send when `repoStatus !== 'indexed'` | #77 |
-
----
-
-## Environment Variables Quick Reference
-
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `OPENAI_API_KEY` | Yes | — | OpenAI API key |
-| `MONGODB_URI` | Yes | — | Atlas connection string (must include `/ragdb`) |
-| `JWT_SECRET` | Yes | insecure default | HS256 signing secret — generate random 32-byte hex |
-| `ALLOWED_ORIGINS` | No | `http://localhost:3000` | Comma-separated CORS origins |
-| `LLM_PROVIDER` | No | `openai` | `openai` or `anthropic` |
-| `LLM_MODEL` | No | `gpt-4o-mini` | Model name |
-| `LLM_MAX_TOKENS` | No | `2000` | Max response tokens |
-| `EMBEDDING_PROVIDER` | No | `openai` | Embedding provider |
-| `EMBEDDING_MODEL` | No | `text-embedding-3-small` | Embedding model |
-| `ANTHROPIC_API_KEY` | Only if provider=anthropic | — | Anthropic key |
-| `COHERE_API_KEY` | No | — | Enables cross-encoder re-ranking |
-| `GITHUB_TOKEN` | No | — | For importing private repos |
-| `ENABLE_CHUNK_SUMMARIES` | No | `false` | LLM summaries at index time (slower) |


### PR DESCRIPTION
Closes #80

## What changed

Three files, all removals of duplicate content:

| File | Change |
|---|---|
| `DEBUGGING_AND_SETUP.md` | Renamed → `TROUBLESHOOTING.md` |
| `TROUBLESHOOTING.md` | Removed "How to Run" (→ README) and env var table (→ docs/deployment.md) |
| `CONTRIBUTING.md` | Removed Development Setup section (→ README); added redirect link |
| `README.md` | Added `TROUBLESHOOTING.md` to docs index and project structure tree |

## Why

- `CONTRIBUTING.md` had a full backend+frontend setup walkthrough that was character-for-character identical to README Quick Start
- `DEBUGGING_AND_SETUP.md` had a "How to Run" section duplicating README and an env var table duplicating docs/deployment.md
- `DEBUGGING_AND_SETUP.md` was invisible — not in README docs index or project structure tree
- `TROUBLESHOOTING.md` is the standard name for this type of file

## After this PR

All unique content is preserved. Net: -130 lines of duplication. Repository documentation is:
- `README.md` — entry point, Quick Start, API reference, links to all docs
- `ARCHITECTURE.md` — technical deep dive with 6 diagrams
- `CONTRIBUTING.md` — PR workflow, code style, branch naming, adding providers
- `TROUBLESHOOTING.md` — common errors, root causes, diagnostic commands
- `docs/deployment.md` — Atlas, Render/Railway, Vercel step-by-step
- `docs/search-pipeline.md` — hybrid search internals
- `docs/provider-architecture.md` — provider abstraction and extension guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)