### PR TITLE
fix: skip 401 interceptor for auth endpoints

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -56,11 +56,16 @@ function App() {
   }, [chatHistory])
 
   // Intercept 401 responses globally — clears expired token and returns to login
+  // Auth endpoints (/auth/login, /auth/register) are excluded — their 401s mean
+  // wrong credentials, not an expired session, and are handled in their own catch blocks.
   useEffect(() => {
+    const AUTH_PATHS = ['/auth/login', '/auth/register', '/auth/refresh']
     const id = axios.interceptors.response.use(
       (res) => res,
       (err) => {
-        if (err.response?.status === 401) {
+        const url = err.config?.url || ''
+        const isAuthEndpoint = AUTH_PATHS.some(p => url.includes(p))
+        if (err.response?.status === 401 && !isAuthEndpoint) {
           setToken('')
           setUsername('')
           localStorage.removeItem('token')


### PR DESCRIPTION
## What

Adds a URL check to the Axios 401 interceptor so it skips `/auth/login`, `/auth/register`, and `/auth/refresh`.

## Why

These endpoints legitimately return 401 for wrong credentials. The interceptor was treating every 401 as an expired session, showing "Session expired — please sign in again" when the user just typed the wrong password.

## Before / After

| Scenario | Before | After |
|---|---|---|
| Wrong password on login | "Session expired" toast (wrong) | "Login failed: Invalid credentials" toast (correct) |
| Expired token on API call | "Session expired" toast ✓ | "Session expired" toast ✓ |

Closes #86