### PR TITLE
feat: implement refresh token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ No frontend env vars needed for local dev — defaults to `http://localhost:8000
 | `COHERE_API_KEY` | No | — | Enables Cohere re-ranking; omit for BM25 fallback |
 | `GITHUB_TOKEN` | No | — | For importing private repositories |
 | `ALLOWED_ORIGINS` | No | `http://localhost:3000` | Comma-separated CORS origins |
+| `ENVIRONMENT` | No | `development` | Set to `production` on Render — enables secure httpOnly cookies |
 
 ---
 
@@ -190,8 +191,10 @@ Authorization: Bearer <access_token>
 
 | Method | Path | Body | Response |
 |---|---|---|---|
-| POST | `/auth/register` | `{username, password}` | `{access_token}` 201 |
-| POST | `/auth/login` | `{username, password}` | `{access_token}` 200 |
+| POST | `/auth/register` | `{username, password}` | `{access_token}` 201 + sets `refresh_token` cookie |
+| POST | `/auth/login` | `{username, password}` | `{access_token}` 200 + sets `refresh_token` cookie |
+| POST | `/auth/refresh` | — (reads httpOnly cookie) | `{access_token}` 200 |
+| POST | `/auth/logout` | — (reads httpOnly cookie) | 200, clears cookie |
 
 ### Repositories
 

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -6,13 +6,16 @@ Handles user registration and login.
 Phase 13: Production Ready
 """
 
-from fastapi import APIRouter, HTTPException, status, Depends
+from fastapi import APIRouter, HTTPException, status, Response, Cookie
 from pydantic import BaseModel
-from datetime import datetime
-from bson import ObjectId
+from datetime import datetime, timedelta
+from typing import Optional
+import os
 from backend.database import Database
-from backend.auth.jwt import create_access_token
+from backend.auth.jwt import create_access_token, create_refresh_token, verify_token, REFRESH_TOKEN_EXPIRE_DAYS
 from passlib.context import CryptContext
+
+IS_PRODUCTION = os.getenv("ENVIRONMENT", "development") == "production"
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -34,71 +37,105 @@ class TokenResponse(BaseModel):
     token_type: str
 
 
+def _set_refresh_cookie(response: Response, token: str) -> None:
+    response.set_cookie(
+        key="refresh_token",
+        value=token,
+        httponly=True,
+        secure=IS_PRODUCTION,
+        samesite="none" if IS_PRODUCTION else "lax",
+        max_age=REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
+    )
+
+
 @router.post("/register", status_code=status.HTTP_201_CREATED)
-async def register(request: RegisterRequest):
-    """
-    POST /auth/register - Register a new user
-    
-    Args:
-        username: Unique username
-        password: User password
-    
-    Returns:
-        Access token
-    """
+async def register(request: RegisterRequest, response: Response):
     db = Database.get_db()
-    
+
     existing = await db.users.find_one({"username": request.username})
     if existing:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Username already exists"
         )
-    
+
     hashed_password = pwd_context.hash(request.password)
-    
-    doc = {
+    result = await db.users.insert_one({
         "username": request.username,
         "password": hashed_password,
         "created_at": datetime.now()
-    }
-    
-    result = await db.users.insert_one(doc)
+    })
     user_id = str(result.inserted_id)
-    
-    token = create_access_token({"sub": user_id, "username": request.username})
-    
-    return {"access_token": token, "token_type": "bearer"}
+
+    access_token = create_access_token({"sub": user_id, "username": request.username})
+    refresh_token = create_refresh_token({"sub": user_id, "username": request.username})
+
+    await db.refresh_tokens.insert_one({
+        "token": refresh_token,
+        "user_id": user_id,
+        "expires_at": datetime.now() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+    })
+
+    _set_refresh_cookie(response, refresh_token)
+    return {"access_token": access_token, "token_type": "bearer"}
 
 
 @router.post("/login", response_model=TokenResponse)
-async def login(request: LoginRequest):
-    """
-    POST /auth/login - Login with username and password
-    
-    Args:
-        username: Username
-        password: Password
-    
-    Returns:
-        Access token
-    """
+async def login(request: LoginRequest, response: Response):
     db = Database.get_db()
-    
+
     user = await db.users.find_one({"username": request.username})
-    if not user:
+    if not user or not pwd_context.verify(request.password, user["password"]):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid credentials"
         )
-    
-    if not pwd_context.verify(request.password, user["password"]):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid credentials"
-        )
-    
+
     user_id = str(user["_id"])
-    token = create_access_token({"sub": user_id, "username": request.username})
-    
-    return {"access_token": token, "token_type": "bearer"}
+    access_token = create_access_token({"sub": user_id, "username": request.username})
+    refresh_token = create_refresh_token({"sub": user_id, "username": request.username})
+
+    await db.refresh_tokens.insert_one({
+        "token": refresh_token,
+        "user_id": user_id,
+        "expires_at": datetime.now() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+    })
+
+    _set_refresh_cookie(response, refresh_token)
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.post("/refresh")
+async def refresh(response: Response, refresh_token: Optional[str] = Cookie(None)):
+    if not refresh_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No refresh token")
+
+    payload = verify_token(refresh_token)
+    if not payload or payload.get("type") != "refresh":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token")
+
+    db = Database.get_db()
+    stored = await db.refresh_tokens.find_one({"token": refresh_token})
+    if not stored:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Refresh token revoked")
+
+    user_id = payload["sub"]
+    username = payload.get("username", "")
+    new_access_token = create_access_token({"sub": user_id, "username": username})
+
+    return {"access_token": new_access_token, "token_type": "bearer"}
+
+
+@router.post("/logout")
+async def logout(response: Response, refresh_token: Optional[str] = Cookie(None)):
+    if refresh_token:
+        db = Database.get_db()
+        await db.refresh_tokens.delete_one({"token": refresh_token})
+
+    response.delete_cookie(
+        key="refresh_token",
+        httponly=True,
+        secure=IS_PRODUCTION,
+        samesite="none" if IS_PRODUCTION else "lax",
+    )
+    return {"message": "Logged out"}

--- a/backend/auth/jwt.py
+++ b/backend/auth/jwt.py
@@ -16,7 +16,8 @@ load_dotenv()
 
 SECRET_KEY = os.getenv("JWT_SECRET", "change-this-in-production-use-strong-secret")
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_HOURS = 24
+ACCESS_TOKEN_EXPIRE_MINUTES = 15
+REFRESH_TOKEN_EXPIRE_DAYS = 7
 
 
 def create_access_token(
@@ -38,7 +39,7 @@ def create_access_token(
     if expires_delta:
         expire = datetime.now(timezone.utc) + expires_delta
     else:
-        expire = datetime.now(timezone.utc) + timedelta(hours=ACCESS_TOKEN_EXPIRE_HOURS)
+        expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
 
     to_encode.update({"exp": expire, "iat": datetime.now(timezone.utc)})
 
@@ -61,6 +62,13 @@ def verify_token(token: str) -> Optional[Dict[str, Any]]:
         return payload
     except JWTError:
         return None
+
+
+def create_refresh_token(data: Dict[str, Any]) -> str:
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode.update({"exp": expire, "iat": datetime.now(timezone.utc), "type": "refresh"})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
 
 def decode_token_unsafe(token: str) -> Optional[Dict[str, Any]]:

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,6 +28,8 @@ async def lifespan(app: FastAPI):
     
     db = Database.get_db()
     await db.users.create_index("username", unique=True)
+    await db.refresh_tokens.create_index("expires_at", expireAfterSeconds=0)
+    await db.refresh_tokens.create_index("user_id")
     print("Users collection indexes initialized")
     
     from backend.services.vector_store import VectorStore

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,8 @@ import './App.css'
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
 
+axios.defaults.withCredentials = true
+
 function App() {
   const [token, setToken] = useState(localStorage.getItem('token') || '')
   const [username, setUsername] = useState(localStorage.getItem('username') || '')
@@ -55,29 +57,68 @@ function App() {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [chatHistory])
 
-  // Intercept 401 responses globally — clears expired token and returns to login
-  // Auth endpoints (/auth/login, /auth/register) are excluded — their 401s mean
-  // wrong credentials, not an expired session, and are handled in their own catch blocks.
+  // Intercept 401 responses — attempt silent token refresh before logging out.
+  // Auth endpoints are excluded: their 401s mean wrong credentials, not expiry.
   useEffect(() => {
     const AUTH_PATHS = ['/auth/login', '/auth/register', '/auth/refresh']
+    let isRefreshing = false
+    let queue = []
+
+    const processQueue = (error, newToken = null) => {
+      queue.forEach(({ resolve, reject }) => error ? reject(error) : resolve(newToken))
+      queue = []
+    }
+
+    const forceLogout = () => {
+      setToken('')
+      setUsername('')
+      localStorage.removeItem('token')
+      localStorage.removeItem('username')
+      setRepositories([])
+      setSessions([])
+      setActiveSessionId(null)
+      setChatHistory([])
+      setSelectedRepo('')
+      showToast('Session expired — please sign in again', 'error')
+    }
+
     const id = axios.interceptors.response.use(
       (res) => res,
-      (err) => {
-        const url = err.config?.url || ''
+      async (err) => {
+        const original = err.config
+        const url = original?.url || ''
         const isAuthEndpoint = AUTH_PATHS.some(p => url.includes(p))
-        if (err.response?.status === 401 && !isAuthEndpoint) {
-          setToken('')
-          setUsername('')
-          localStorage.removeItem('token')
-          localStorage.removeItem('username')
-          setRepositories([])
-          setSessions([])
-          setActiveSessionId(null)
-          setChatHistory([])
-          setSelectedRepo('')
-          showToast('Session expired — please sign in again', 'error')
+
+        if (err.response?.status !== 401 || isAuthEndpoint || original._retry) {
+          return Promise.reject(err)
         }
-        return Promise.reject(err)
+
+        if (isRefreshing) {
+          return new Promise((resolve, reject) => queue.push({ resolve, reject }))
+            .then(newToken => {
+              original.headers.Authorization = `Bearer ${newToken}`
+              return axios(original)
+            })
+        }
+
+        original._retry = true
+        isRefreshing = true
+
+        try {
+          const res = await axios.post(`${API_URL}/auth/refresh`)
+          const newToken = res.data.access_token
+          setToken(newToken)
+          localStorage.setItem('token', newToken)
+          original.headers.Authorization = `Bearer ${newToken}`
+          processQueue(null, newToken)
+          return axios(original)
+        } catch {
+          processQueue(new Error('Refresh failed'), null)
+          forceLogout()
+          return Promise.reject(err)
+        } finally {
+          isRefreshing = false
+        }
       }
     )
     return () => axios.interceptors.response.eject(id)
@@ -168,7 +209,8 @@ function App() {
     }
   }
 
-  const logout = () => {
+  const logout = async () => {
+    try { await axios.post(`${API_URL}/auth/logout`) } catch {}
     setToken('')
     setUsername('')
     localStorage.removeItem('token')


### PR DESCRIPTION
## What

Two-token auth system replacing the single 24-hour JWT.

| | Before | After |
|---|---|---|
| Access token TTL | 24 hours | 15 minutes |
| Session length | 24 hours, then re-login | 7 days, silently renewed |
| Token on logout | Just cleared from localStorage | Revoked on server + cookie cleared |

## How it works

**Login/Register** — issues an access token (JSON body) and a refresh token (httpOnly cookie). The cookie is `secure` + `samesite=none` in production so it works cross-origin between Vercel and Render.

**Silent refresh** — when any API call returns 401, the interceptor calls `POST /auth/refresh` before logging the user out. If the refresh succeeds, the original request is retried with the new token. Concurrent 401s are queued so only one refresh call fires.

**Logout** — calls `POST /auth/logout` which deletes the refresh token from MongoDB and clears the cookie server-side.

**Cleanup** — MongoDB TTL index on `refresh_tokens.expires_at` auto-deletes expired tokens.

## Deploy note

Add `ENVIRONMENT=production` to Render environment variables — this switches the cookie to `secure=True` / `samesite=none` which is required for cross-origin cookies over HTTPS.

Closes #87